### PR TITLE
Added missing ping endpoint as used by Kubernetes for liveliness probe

### DIFF
--- a/integration_tests/integration/health.spec.js
+++ b/integration_tests/integration/health.spec.js
@@ -8,4 +8,7 @@ context('Healthcheck', () => {
   it('Health check page is visible', () => {
     cy.request('/health').its('body.healthy').should('equal', true)
   })
+  it('Ping is visible and UP', () => {
+    cy.request('/ping').its('body.status').should('equal', 'UP')
+  })
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -138,6 +138,11 @@ export default function createApp(userService: UserService): express.Application
       res.json(result)
     })
   })
+  app.get('/ping', (req, res) =>
+    res.send({
+      status: 'UP',
+    })
+  )
 
   // GovUK Template Configuration
   app.locals.asset_path = '/assets/'


### PR DESCRIPTION
Interestingly because of the redirect to HMPSS Auth Kubernetes was mostly happy, though it does a generate a load of bad probes 