### PR TITLE
Fix the slack notification on `check_outdated`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ executors:
       - image: circleci/redis:buster
     working_directory: ~/app
 
+parameters:
+  alerts-slack-channel:
+    type: string
+    default: hmpps_typescript_notifications
+
 jobs:
   build:
     executor:
@@ -69,7 +74,7 @@ jobs:
           command: 'npm outdated typescript govuk-frontend'
       - slack/notify:
           event: fail
-          channel: hmpps_typescript_notifications
+          channel: << pipeline.parameters.alerts-slack-channel >>
           template: basic_fail_1
 
   unit_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,9 @@ workflows:
               only:
                 - main
     jobs:
-      - check_outdated
+      - check_outdated:
+          context:
+            - hmpps-common-vars
       - hmpps/npm_security_audit:
           context:
             - hmpps-common-vars


### PR DESCRIPTION
These changes ensure the notification works out of the box and adds in a slight refactor to set a dry/reusable pattern.