### PR TITLE
Fixing configuration of security audit

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,5 @@
 {
-  "medium": true,
+  "low": true,
   "package-manager": "auto",
   "registry": "https://registry.npmjs.org"
 }


### PR DESCRIPTION
The "medium" configuration was not an acceptable term, should be one of "info", "low", "moderate", "high" or "critical". This meant that it would not pick up on anything!