### PR TITLE
Fixing docker caching issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
 
   node-version:
     type: string
-    default: 16.13-browsers
+    default: 16.14-browsers
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:16.13-bullseye-slim as base
+FROM node:16.14-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
@@ -10,14 +10,17 @@ ENV TZ=Europe/London
 RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
 
 RUN addgroup --gid 2000 --system appgroup && \
-    adduser --uid 2000 --system appuser --gid 2000
+        adduser --uid 2000 --system appuser --gid 2000
 
 WORKDIR /app
 
+# Cache breaking
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+        apt-get upgrade -y && \
+        apt-get autoremove -y && \
+        rm -rf /var/lib/apt/lists/*
 
 # Stage: build assets
 FROM base as build
@@ -26,7 +29,7 @@ ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
 
 RUN apt-get update && \
-    apt-get install -y make python g++
+        apt-get install -y make python g++
 
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit
@@ -35,8 +38,8 @@ COPY . .
 RUN npm run build
 
 RUN export BUILD_NUMBER=${BUILD_NUMBER} && \
-    export GIT_REF=${GIT_REF} && \
-    npm run record-build-info
+        export GIT_REF=${GIT_REF} && \
+        npm run record-build-info
 
 RUN npm prune --no-audit --production
 

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -1,8 +1,9 @@
 declare namespace Cypress {
   interface Chainable {
-    /**   * Custom command to signIn. Set failOnStatusCode to false if you expect and non 200 return code
+    /**
+     * Custom command to signIn. Set failOnStatusCode to false if you expect and non 200 return code
      * @example cy.signIn({ failOnStatusCode: boolean })
      */
-    signIn<S = unknown>(options?: { failOnStatusCode: false }): Chainable<S>
+    signIn(options?: { failOnStatusCode: boolean }): Chainable<AUTWindow>
   }
 }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,4 +1,4 @@
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
-  cy.request(`/`)
-  cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
+  cy.request('/')
+  return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })


### PR DESCRIPTION
Need to refer to build args before calling apt-get upgrade otherwise the set of packages are cached and not upgraded. Docker cannot cache anything in layers after a dynamic variable has been used

Also bumping version of node and fixing test compilation issue