### PR TITLE
Setup prometheus metrics by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=build --chown=appuser:appgroup \
 COPY --from=build --chown=appuser:appgroup \
         /app/node_modules ./node_modules
 
-EXPOSE 3000
+EXPOSE 3000 3001
 ENV NODE_ENV='production'
 USER 2000
 

--- a/helm_deploy/hmpps-template-typescript/Chart.yaml
+++ b/helm_deploy/hmpps-template-typescript/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-template-typescript
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.0.16
+    version: 1.2.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.1.4
+    version: 0.4.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-template-typescript/values.yaml
+++ b/helm_deploy/hmpps-template-typescript/values.yaml
@@ -22,6 +22,12 @@ generic-service:
     httpGet:
       path: /ping
 
+  custommetrics:
+    enabled: true
+    scrapeInterval: 15s
+    metricsPath: /metrics
+    metricsPort: 3001
+
   # Environment variables to load into the deployment
   env:
     NODE_ENV: "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "dotenv": "^16.0.0",
         "eslint-plugin-no-only-tests": "^2.6.0",
         "express": "^4.17.3",
+        "express-prom-bundle": "^6.4.1",
         "express-session": "^1.17.2",
         "govuk-frontend": "^4.0.1",
         "helmet": "^5.0.2",
@@ -33,8 +34,10 @@
         "nunjucks": "^3.2.3",
         "passport": "^0.5.2",
         "passport-oauth2": "^1.6.1",
+        "prom-client": "^14.0.1",
         "redis": "^4.0.4",
         "superagent": "^7.1.1",
+        "url-value-parser": "^2.1.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -3997,6 +4000,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -6263,6 +6271,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-prom-bundle": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.4.1.tgz",
+      "integrity": "sha512-Sg0svLQe/SS5z1tHDTVfZVjNumobiDlXM0jmemt5Dm9K6BX8z9yCwEr93zbko6fNMR4zKav77iPfxUWi6gAjNA==",
+      "dependencies": {
+        "on-finished": "^2.3.0",
+        "url-value-parser": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "prom-client": ">=12.0.0"
       }
     },
     "node_modules/express-session": {
@@ -10971,6 +10994,17 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -12179,6 +12213,14 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dependencies": {
+        "bintrees": "1.0.1"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -12727,6 +12769,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/url-value-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.1.0.tgz",
+      "integrity": "sha512-gIYPWXujdUdwd/9TGCHTf5Vvgw6lOxjE5Q/k+7WNByYyS0vW5WX0k+xuVlhvPq6gRNhzXVv/ezC+OfeAet5Kcw==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -16110,6 +16160,11 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "devOptional": true
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -17877,6 +17932,15 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
+      }
+    },
+    "express-prom-bundle": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.4.1.tgz",
+      "integrity": "sha512-Sg0svLQe/SS5z1tHDTVfZVjNumobiDlXM0jmemt5Dm9K6BX8z9yCwEr93zbko6fNMR4zKav77iPfxUWi6gAjNA==",
+      "requires": {
+        "on-finished": "^2.3.0",
+        "url-value-parser": "^2.0.0"
       }
     },
     "express-session": {
@@ -21424,6 +21488,14 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
+    "prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -22352,6 +22424,14 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -22757,6 +22837,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-value-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.1.0.tgz",
+      "integrity": "sha512-gIYPWXujdUdwd/9TGCHTf5Vvgw6lOxjE5Q/k+7WNByYyS0vW5WX0k+xuVlhvPq6gRNhzXVv/ezC+OfeAet5Kcw=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "dotenv": "^16.0.0",
     "eslint-plugin-no-only-tests": "^2.6.0",
     "express": "^4.17.3",
+    "express-prom-bundle": "^6.4.1",
     "express-session": "^1.17.2",
     "govuk-frontend": "^4.0.1",
     "helmet": "^5.0.2",
@@ -108,8 +109,10 @@
     "nunjucks": "^3.2.3",
     "passport": "^0.5.2",
     "passport-oauth2": "^1.6.1",
+    "prom-client": "^14.0.1",
     "redis": "^4.0.4",
     "superagent": "^7.1.1",
+    "url-value-parser": "^2.1.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/server.ts
+++ b/server.ts
@@ -8,9 +8,13 @@ import { initialiseAppInsights, buildAppInsightsClient } from './server/utils/az
 initialiseAppInsights()
 buildAppInsightsClient()
 
-import app from './server/index'
+import { app, metricsApp } from './server/index'
 import logger from './logger'
 
 app.listen(app.get('port'), () => {
   logger.info(`Server listening on port ${app.get('port')}`)
+})
+
+metricsApp.listen(metricsApp.get('port'), () => {
+  logger.info(`Metrics server listening on port ${metricsApp.get('port')}`)
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -16,6 +16,7 @@ import setUpAuthentication from './middleware/setUpAuthentication'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
+import { metricsMiddleware } from './monitoring/metricsApp'
 
 export default function createApp(userService: UserService): express.Application {
   const app = express()
@@ -24,6 +25,7 @@ export default function createApp(userService: UserService): express.Application
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
+  app.use(metricsMiddleware)
   app.use(setUpHealthChecks())
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -6,6 +6,7 @@ import logger from '../../logger'
 import sanitiseError from '../sanitisedError'
 import { ApiConfig } from '../config'
 import type { UnsanitisedError } from '../sanitisedError'
+import { restClientMetricsMiddleware } from './restClientMetricsMiddleware'
 
 interface GetRequest {
   path?: string
@@ -50,6 +51,7 @@ export default class RestClient {
       const result = await superagent
         .get(`${this.apiUrl()}${path}`)
         .agent(this.agent)
+        .use(restClientMetricsMiddleware)
         .retry(2, (err, res) => {
           if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
           return undefined // retry handler only for logging retries, not to influence retry logic
@@ -81,6 +83,7 @@ export default class RestClient {
         .post(`${this.apiUrl()}${path}`)
         .send(data)
         .agent(this.agent)
+        .use(restClientMetricsMiddleware)
         .retry(2, (err, res) => {
           if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
           return undefined // retry handler only for logging retries, not to influence retry logic
@@ -105,6 +108,7 @@ export default class RestClient {
         .get(`${this.apiUrl()}${path}`)
         .agent(this.agent)
         .auth(this.token, { type: 'bearer' })
+        .use(restClientMetricsMiddleware)
         .retry(2, (err, res) => {
           if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
           return undefined // retry handler only for logging retries, not to influence retry logic

--- a/server/data/restClientMetricsMiddleware.test.ts
+++ b/server/data/restClientMetricsMiddleware.test.ts
@@ -1,0 +1,72 @@
+import superagent from 'superagent'
+import {
+  restClientMetricsMiddleware,
+  normalizePath,
+  requestHistogram,
+  timeoutCounter,
+} from './restClientMetricsMiddleware'
+
+describe('restClientMetricsMiddleware', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('normalizePath', () => {
+    it('removes the query params from the URL path', () => {
+      const result = normalizePath('https://httpbin.org/?foo=bar')
+      expect(result).toBe('/')
+    })
+
+    it('normalises recall ids', () => {
+      const result = normalizePath(
+        'https://manage-recalls-dev.hmpps.service.justice.gov.uk/recalls/15e4cccf-cc7b-4946-aa22-a82086735ec2/view-recall'
+      )
+      expect(result).toBe('/recalls/#val/view-recall')
+    })
+
+    it('normalises nomis ids', () => {
+      const result = normalizePath('https://manage-recalls-dev.hmpps.service.justice.gov.uk/prisoner/A7826DY')
+      expect(result).toBe('/prisoner/#val')
+    })
+  })
+
+  describe('request timers', () => {
+    it('times the whole request', async () => {
+      const requestHistogramLabelsSpy = jest.spyOn(requestHistogram, 'labels').mockReturnValue(requestHistogram)
+      const requestHistogramStartSpy = jest.spyOn(requestHistogram, 'observe')
+
+      let code: number
+
+      await superagent
+        .get('https://httpbin.org/')
+        .use(restClientMetricsMiddleware)
+        .set('accept', 'json')
+        .then(res => {
+          code = res.statusCode
+        })
+
+      expect(code).toBe(200)
+      expect(requestHistogramLabelsSpy).toHaveBeenCalledTimes(1)
+      expect(requestHistogramLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'GET', '/', '200')
+      expect(requestHistogramStartSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('timeout errors', () => {
+    // FIXME: For some reason this test just doesn't work, but the code really does count the timeouts...
+    it.skip('increment the timeoutCounter', async () => {
+      const timeoutCounterLabelsSpy = jest.spyOn(timeoutCounter, 'labels').mockReturnValue(timeoutCounter)
+      const timeoutCounterIncSpy = jest.spyOn(timeoutCounter, 'inc')
+
+      await superagent
+        .get('https://httpbin.org/delay/5') // implements a delay of 5 seconds
+        .use(restClientMetricsMiddleware)
+        .set('accept', 'json')
+        .timeout(100) // Wait 100ms for the server to start sending
+        .end()
+
+      expect(timeoutCounterLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'GET', '/delay/5')
+      expect(timeoutCounterIncSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/server/data/restClientMetricsMiddleware.ts
+++ b/server/data/restClientMetricsMiddleware.ts
@@ -1,0 +1,49 @@
+import { Socket } from 'net'
+import promClient from 'prom-client'
+import { Response, SuperAgentRequest } from 'superagent'
+import UrlValueParser from 'url-value-parser'
+
+const requestHistogram = new promClient.Histogram({
+  name: 'http_client_requests_seconds',
+  help: 'Timings and counts of http client requests',
+  buckets: [0.5, 0.75, 0.95, 0.99, 1],
+  labelNames: ['clientName', 'method', 'uri', 'status'],
+})
+
+const timeoutCounter = new promClient.Counter({
+  name: 'http_client_requests_timeout_total',
+  help: 'Count of http client request timeouts',
+  labelNames: ['clientName', 'method', 'uri'],
+})
+
+function restClientMetricsMiddleware(agent: SuperAgentRequest) {
+  agent.on('request', ({ req }) => {
+    const { hostname } = new URL(agent.url)
+    const normalizedPath = normalizePath(agent.url)
+    const startTime = Date.now()
+
+    req.on('socket', (socket: Socket) => {
+      socket.on('timeout', () => {
+        timeoutCounter.labels(hostname, req.method, normalizedPath).inc()
+      })
+    })
+
+    req.on('response', (res: Response, err: Error) => {
+      res.on('end', () => {
+        const responseTime = Date.now() - startTime
+        requestHistogram.labels(hostname, req.method, normalizedPath, String(res.statusCode)).observe(responseTime)
+      })
+    })
+  })
+
+  return agent
+}
+
+function normalizePath(url: string) {
+  const { pathname } = new URL(url)
+  const urlPathReplacement = '#val'
+  const urlValueParser = new UrlValueParser({ extraMasks: [/^[A-Z|0-9]+/] })
+  return urlValueParser.replacePathValues(pathname, urlPathReplacement)
+}
+
+export { restClientMetricsMiddleware, normalizePath, requestHistogram, timeoutCounter }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,17 @@
+import promClient from 'prom-client'
+import { createMetricsApp } from './monitoring/metricsApp'
+import { createRedisClient } from './data/redisClient'
 import createApp from './app'
 import HmppsAuthClient from './data/hmppsAuthClient'
-import { createRedisClient } from './data/redisClient'
 import TokenStore from './data/tokenStore'
 import UserService from './services/userService'
+
+promClient.collectDefaultMetrics()
 
 const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient()))
 const userService = new UserService(hmppsAuthClient)
 
 const app = createApp(userService)
+const metricsApp = createMetricsApp()
 
-export default app
+export { app, metricsApp }

--- a/server/monitoring/metricsApp.ts
+++ b/server/monitoring/metricsApp.ts
@@ -1,0 +1,28 @@
+import express from 'express'
+import promBundle from 'express-prom-bundle'
+
+const metricsMiddleware = promBundle({
+  autoregister: false,
+  buckets: [0.5, 0.75, 0.95, 0.99, 1],
+  httpDurationMetricName: 'http_server_requests_seconds',
+  includeMethod: true,
+  includePath: true,
+  normalizePath: [['^/assets/.+$', '/assets/#assetPath']],
+})
+
+function metricsPort(): number {
+  let port = 3000
+  if (process.env.PORT != null) {
+    port = Number(process.env.PORT)
+  }
+  return port + 1
+}
+
+function createMetricsApp(): express.Application {
+  const metricsApp = express()
+  metricsApp.use(metricsMiddleware.metricsMiddleware)
+  metricsApp.set('port', metricsPort())
+  return metricsApp
+}
+
+export { metricsMiddleware, createMetricsApp }

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -1,6 +1,13 @@
+import promClient from 'prom-client'
 import { serviceCheckFactory } from '../data/healthCheck'
 import config from '../config'
 import type { AgentConfig } from '../config'
+
+const healthCheckGauge = new promClient.Gauge({
+  name: 'upstream_healthcheck',
+  help: 'health of an upstream dependency - 1 = healthy, 0 = not healthy',
+  labelNames: ['service'],
+})
 
 interface HealthCheckStatus {
   name: string
@@ -69,6 +76,11 @@ export default function healthCheck(callback: HealthCheckCallback, checks = apiC
       healthy: allOk,
       checks: checkResults.reduce(gatherCheckInfo, {}),
     }
+
+    checkResults.forEach(item => {
+      const val = item.status === 'ok' ? 1 : 0
+      healthCheckGauge.labels(item.name).set(val)
+    })
 
     callback(addAppInfo(result))
   })


### PR DESCRIPTION
This change sets up prometheus metrics to be available on port 3001, and
with the helm chart changes they will automatically get scraped and be
available for alerts and dashboards in grafana.

The added metrics include:

- General nodejs stats: memory use, gc etc
- HTTP server requests: counters and timings of all served HTTP requests
  by the app.
- HTTP client requests: counters and timings of all HTTP requests to
  other upstream APIs (as long as they are based off `restClient.ts`).
- Upstream healthchecks: guages recording the status/health of each
  upstream service when the healthcheck is tested.

This is all backported from the `manage-recalls-ui` app, please let me
know what you think. :)