### PR TITLE
SLM-245 Restore cache prior to running the app for the integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,8 @@ jobs:
       - run:
           name: Install missing OS dependency
           command: sudo apt-get install libxss1
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get wiremock
           command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.1/wiremock-standalone-2.27.1.jar
@@ -123,8 +125,6 @@ jobs:
       - run:
           name: Wait for node app to start
           command: sleep 5
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: integration tests
           command: npm run int-test


### PR DESCRIPTION
This caused an issue with our build where we received a segmentation fault as soon as the integration tests called the node app. Segmentation faults generally indicate an issue with one of the native C/C++ modules and it appears that one of these modules was relying on something we have stashed in the cache (is my best guess!)