### PR TITLE
Remove duplicate <main> elements

### DIFF
--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -1,13 +1,12 @@
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Error" %}
+{% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
 
-  <main class="app-container">
-    <h1>{{ message }}</h1>
-    <h2>{{ status }}</h2>
-    <pre>{{ stack }}</pre>
-  </main>
+  <h1>{{ message }}</h1>
+  <h2>{{ status }}</h2>
+  <pre>{{ stack }}</pre>
 
 {% endblock %}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -1,12 +1,11 @@
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
+{% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
 
-  <main class="app-container govuk-body">
-    <h1>This site is under construction...</h1>
-    <p>Please check back later when there is content to view.</p>
-  </main>
+  <h1>This site is under construction...</h1>
+  <p>Please check back later when there is content to view.</p>
 
 {% endblock %}


### PR DESCRIPTION
The `index.njk` and `error.njk` files use `layout.njk` which extends `govuk/template.njk`. `govuk/template.njk` already includes a `<main>` element.

[According to the HTML spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element) there should only be one `<main>` element present in the document at a time. Having multiple `<main>` elements could affect screen readers and other assistive technologies.

(NB the link in the [contributing guidelines](https://github.com/ministryofjustice/.github/blob/23444d612e846ceca655dc18c2a040c56a9f2f80/CONTRIBUTING.md) to [GDS guidance on commit hygene](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages) is dead so please let me know if there any improvements that need to be made to the commit message)