### PR TITLE
 Add a `cspNonce` to the webSecurity setup

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,5 +1,6 @@
-import express, { Router } from 'express'
+import express, { Router, Request, Response, NextFunction } from 'express'
 import helmet from 'helmet'
+import crypto from 'crypto'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
@@ -7,14 +8,23 @@ export default function setUpWebSecurity(): Router {
   // Secure code best practice - see:
   // 1. https://expressjs.com/en/advanced/best-practice-security.html,
   // 2. https://www.npmjs.com/package/helmet
+  router.use((_req: Request, res: Response, next: NextFunction) => {
+    res.locals.cspNonce = crypto.randomBytes(16).toString('hex')
+    next()
+  })
   router.use(
     helmet({
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],
-          // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
-          scriptSrc: ["'self'", 'code.jquery.com', "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"],
-          styleSrc: ["'self'", 'code.jquery.com'],
+          // This nonce allows us to use scripts with the use of the `cspNonce` local, e.g (in a Nunjucks template):
+          // <script nonce="{{ cspNonce }}">
+          // or
+          // <link href="http://example.com/" rel="stylesheet" nonce="{{ cspNonce }}">
+          // This ensures only scripts we trust are loaded, and not anything injected into the
+          // page by an attacker.
+          scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
+          styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           fontSrc: ["'self'"],
         },
       },

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -13,8 +13,9 @@
   <script src="/assets/js/jquery.min.js"></script> 
   <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
           integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
+          nonce="{{ cspNonce }}"
           crossorigin="anonymous"></script>
-  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" crossorigin>
+  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" nonce="{{ cspNonce }}" crossorigin>
 
 {% endblock %}
 


### PR DESCRIPTION
Based on what I’ve seen elsewhere, this seems to now be a common approach to allow us to inline scripts, see:

https://content-security-policy.com/nonce

The GOV.UK frontend has now been updated to support the use of the `cspNonce` local - see:

 https://github.com/alphagov/govuk-frontend/commit/2e40d744af6e6e4213ebc47644982d4eb94422d4

So we no longer need to add the inline hash, which is vulnerable to if the code in the frontend template is changed.

I’ve also removed the domain-specific overrides for jQuery scripts and styles, as we can use the nonce for this too.