### PR TITLE
Fix conflicting prettier / eslint rule

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 120,
   "semi": false,


### PR DESCRIPTION
In eslint, we ask for a trailing comma, while the prettier rules are set to `es5`. This causes issues if you have your IDE set up to fix on save, as one linter kicks in before the other, causing conflicting fixes.