### PR TITLE
Revert build_multiplatform_docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
             - build
       - hmpps/helm_lint:
           name: helm_lint
-      - hmpps/build_multiplatform_docker:
+      - hmpps/build_docker:
           name: build_docker
           filters:
             branches:


### PR DESCRIPTION
because it causes the build to take over an hour

[See Slack discussion](https://mojdt.slack.com/archives/C69NWE339/p1671529301455009?thread_ts=1671529075.740459&cid=C69NWE339)