### PR TITLE
Point to correct locations for applicationVersion

### DIFF
--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -1,9 +1,9 @@
 // eslint-disable import/no-unresolved,global-require
 import fs from 'fs'
 
-const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
-const buildNumber = fs.existsSync('./build-info.json')
-  ? JSON.parse(fs.readFileSync('./build-info.json').toString()).buildNumber
+const packageData = JSON.parse(fs.readFileSync('../package.json').toString())
+const buildNumber = fs.existsSync('../build-info.json')
+  ? JSON.parse(fs.readFileSync('../build-info.json').toString()).buildNumber
   : packageData.version
 
 export default { buildNumber, packageData }


### PR DESCRIPTION
The generated build-info.json and package.json files are in the parent directory.  
This was causing issues for us in Approved Premises so I thought it would be worthwhile fixing upstream.