### PR TITLE
Tie css cache to version of application

### DIFF
--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -2,8 +2,8 @@
 import fs from 'fs'
 
 const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
-const buildNumber = fs.existsSync('./build-info.json')
-  ? JSON.parse(fs.readFileSync('./build-info.json').toString()).buildNumber
-  : packageData.version
+const { buildNumber, gitRef } = fs.existsSync('./build-info.json')
+  ? JSON.parse(fs.readFileSync('./build-info.json').toString())
+  : { buildNumber: packageData.version, gitRef: 'xxxxxxxx' }
 
-export default { buildNumber, packageData }
+export default { buildNumber, packageData, shortHash: gitRef.substring(0, 8) }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -3,6 +3,7 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
 import { initialiseName } from './utils'
+import applicationVersion from '../applicationVersion'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -14,8 +15,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   // Cachebusting version string
   if (production) {
-    // Version only changes on reboot
-    app.locals.version = Date.now().toString()
+    // Version only changes with new commits
+    app.locals.version = applicationVersion.shortHash
   } else {
     // Version changes every request
     app.use((req, res, next) => {


### PR DESCRIPTION
At the moment the cache is linked to the start up time of pod, so get unnecessary cache misses for every client, for each pod in the cluster and also as pods restart

This ties the cache to the git short hash of the deployment rather than having a cached version for each pod