### PR TITLE
Have `sanitisedError` always return an Error instance

### DIFF
--- a/server/sanitisedError.test.ts
+++ b/server/sanitisedError.test.ts
@@ -36,19 +36,21 @@ describe('sanitised error', () => {
     expect(sanitisedError(error)).toEqual(e)
   })
 
-  it('it should return the error message ', () => {
+  it('it should return the error message', () => {
     const error = {
       message: 'error description',
     } as unknown as UnsanitisedError
-    expect(sanitisedError(error)).toEqual({
-      message: 'error description',
-    })
+
+    expect(sanitisedError(error)).toBeInstanceOf(Error)
+    expect(sanitisedError(error)).toHaveProperty('message', 'error description')
   })
 
-  it('it should return an empty object for an unknown error structure', () => {
+  it('it should return an empty Error instance for an unknown error structure', () => {
     const error = {
       property: 'unknown',
     } as unknown as UnsanitisedError
-    expect(sanitisedError(error)).toEqual({})
+
+    expect(sanitisedError(error)).toBeInstanceOf(Error)
+    expect(sanitisedError(error)).not.toHaveProperty('property')
   })
 })

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,6 +1,6 @@
 import type { ResponseError } from 'superagent'
 
-export interface SanitisedError {
+export interface SanitisedError extends Error {
   text?: string
   status?: number
   headers?: unknown
@@ -12,18 +12,14 @@ export interface SanitisedError {
 export type UnsanitisedError = ResponseError
 
 export default function sanitise(error: UnsanitisedError): SanitisedError {
+  const e = new Error() as SanitisedError
+  e.message = error.message
+  e.stack = error.stack
   if (error.response) {
-    const e = new Error(error.message) as SanitisedError
     e.text = error.response.text
     e.status = error.response.status
     e.headers = error.response.headers
     e.data = error.response.body
-    e.message = error.message
-    e.stack = error.stack
-    return e
   }
-  return {
-    message: error.message,
-    stack: error.stack,
-  }
+  return e
 }


### PR DESCRIPTION
… for the same reasons as explained in #197