### PR TITLE
SDIT-1088: ✨ Get components to always return status even if failed

### DIFF
--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -27,7 +27,8 @@ context('Healthcheck', () => {
 
       cy.request({ url: '/health', method: 'GET', failOnStatusCode: false }).then(response => {
         expect(response.body.components.hmppsAuth.status).to.equal('UP')
-        expect(response.body.components.tokenVerification.status).to.contain({ status: 500, retries: 2 })
+        expect(response.body.components.tokenVerification.status).to.equal('DOWN')
+        expect(response.body.components.tokenVerification.details).to.contain({ status: 500, retries: 2 })
       })
     })
   })

--- a/server/services/healthCheck.test.ts
+++ b/server/services/healthCheck.test.ts
@@ -20,10 +20,12 @@ describe('Healthcheck', () => {
           status: 'UP',
           components: {
             check1: {
-              status: 'some message',
+              status: 'UP',
+              details: 'some message',
             },
             check2: {
-              status: 'some message',
+              status: 'UP',
+              details: 'some message',
             },
           },
         }),
@@ -43,10 +45,12 @@ describe('Healthcheck', () => {
           status: 'DOWN',
           components: {
             check1: {
-              status: 'some message',
+              status: 'UP',
+              details: 'some message',
             },
             check2: {
-              status: 'some error',
+              status: 'DOWN',
+              details: 'some error',
             },
           },
         }),

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -46,7 +46,7 @@ function addAppInfo(result: HealthCheckResult, applicationInfo: ApplicationInfo)
 }
 
 function gatherCheckInfo(aggregateStatus: Record<string, unknown>, currentStatus: HealthCheckStatus) {
-  return { ...aggregateStatus, [currentStatus.name]: { status: currentStatus.message } }
+  return { ...aggregateStatus, [currentStatus.name]: { status: currentStatus.status, details: currentStatus.message } }
 }
 
 const apiChecks = [


### PR DESCRIPTION
Change so that we always return `status` to match spring boot.
e.g. spring boot returns:
```json
        "restrictedPatientsApi": {
            "details": {
                "error": "org.springframework.web.reactive.function.client.WebClientRequestException: Connection refused: localhost/[0:0:0:0:0:0:0:1]:8095"
            },
            "status": "DOWN"
        }
```
and we now return 
```json
"hmppsAuth": {
      "status": "DOWN",
      "details": {
        "status": 500,
        "response": {
          "req": {
            "method": "GET",
            "url": "http://localhost:9091/auth/health/ping",
            "headers": {}
          },
          "header": {
            "matched-stub-id": "7f0f22d4-26f1-4d8a-ac83-9c2aa09729cb",
            "transfer-encoding": "chunked"
          },
          "status": 500,
          "text": ""
        },
        "retries": 2
      }
    },
```