### PR TITLE
NON-270: Improve REST client

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,3 +1,5 @@
+import type { UserDetails } from '../../services/userService'
+
 export default {}
 
 declare module 'express-session' {
@@ -10,8 +12,7 @@ declare module 'express-session' {
 
 export declare global {
   namespace Express {
-    interface User {
-      username: string
+    interface User extends Partial<UserDetails> {
       token: string
       authSource: string
     }
@@ -20,6 +21,10 @@ export declare global {
       verified?: boolean
       id: string
       logout(done: (err: unknown) => void): void
+    }
+
+    interface Locals {
+      user: Express.User
     }
   }
 }

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -67,7 +67,7 @@ describe('hmppsAuthClient', () => {
       tokenStore.getToken.mockResolvedValue(null)
 
       fakeHmppsAuthApi
-        .post(`/oauth/token`, 'grant_type=client_credentials&username=Bob')
+        .post('/oauth/token', 'grant_type=client_credentials&username=Bob')
         .basicAuth({ user: config.apis.hmppsAuth.systemClientId, pass: config.apis.hmppsAuth.systemClientSecret })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, token)
@@ -82,7 +82,7 @@ describe('hmppsAuthClient', () => {
       tokenStore.getToken.mockResolvedValue(null)
 
       fakeHmppsAuthApi
-        .post(`/oauth/token`, 'grant_type=client_credentials')
+        .post('/oauth/token', 'grant_type=client_credentials')
         .basicAuth({ user: config.apis.hmppsAuth.systemClientId, pass: config.apis.hmppsAuth.systemClientSecret })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -1,4 +1,5 @@
 import { URLSearchParams } from 'url'
+
 import superagent from 'superagent'
 
 import type TokenStore from './tokenStore'
@@ -32,8 +33,14 @@ function getSystemClientTokenFromHmppsAuth(username?: string): Promise<superagen
 }
 
 export interface User {
-  name: string
-  activeCaseLoadId: string
+  username: string
+  name?: string
+  active?: boolean
+  authSource?: string
+  uuid?: string
+  userId?: string
+  staffId?: number // deprecated, use userId
+  activeCaseLoadId?: string // deprecated, use user roles api
 }
 
 export interface UserRole {
@@ -48,14 +55,14 @@ export default class HmppsAuthClient {
   }
 
   getUser(token: string): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
+    logger.info('Getting user details: calling HMPPS Auth')
+    return HmppsAuthClient.restClient(token).get<User>({ path: '/api/user/me' })
   }
 
   getUserRoles(token: string): Promise<string[]> {
     return HmppsAuthClient.restClient(token)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
+      .get<UserRole[]>({ path: '/api/user/me/roles' })
+      .then(roles => roles.map(role => role.roleCode))
   }
 
   async getSystemClientToken(username?: string): Promise<string> {

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -1,27 +1,24 @@
 import { Readable } from 'stream'
-import superagent from 'superagent'
+
 import Agent, { HttpsAgent } from 'agentkeepalive'
+import superagent from 'superagent'
 
 import logger from '../../logger'
 import sanitiseError from '../sanitisedError'
-import { ApiConfig } from '../config'
+import type { ApiConfig } from '../config'
 import type { UnsanitisedError } from '../sanitisedError'
 import { restClientMetricsMiddleware } from './restClientMetricsMiddleware'
 
-interface GetRequest {
-  path?: string
-  query?: string
+interface Request {
+  path: string
+  query?: object | string
   headers?: Record<string, string>
   responseType?: string
   raw?: boolean
 }
 
-interface PostRequest {
-  path?: string
-  headers?: Record<string, string>
-  responseType?: string
+interface RequestWithBody extends Request {
   data?: Record<string, unknown>
-  raw?: boolean
   retry?: boolean
 }
 
@@ -50,18 +47,24 @@ export default class RestClient {
     return this.config.timeout
   }
 
-  async get({ path = null, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
-    logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
+  async get<Response = unknown>({
+    path,
+    query = {},
+    headers = {},
+    responseType = '',
+    raw = false,
+  }: Request): Promise<Response> {
+    logger.info(`${this.name} GET: ${path}`)
     try {
       const result = await superagent
         .get(`${this.apiUrl()}${path}`)
+        .query(query)
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
         .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          if (err) logger.info(`Retry handler found ${this.name} API error with ${err.code} ${err.message}`)
           return undefined // retry handler only for logging retries, not to influence retry logic
         })
-        .query(query)
         .auth(this.token, { type: 'bearer' })
         .set(headers)
         .responseType(responseType)
@@ -70,23 +73,19 @@ export default class RestClient {
       return raw ? result : result.body
     } catch (error) {
       const sanitisedError = sanitiseError(error)
-      logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
+      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
       throw sanitisedError
     }
   }
 
-  async post({
-    path = null,
-    headers = {},
-    responseType = '',
-    data = {},
-    raw = false,
-    retry = false,
-  }: PostRequest = {}): Promise<unknown> {
-    logger.info(`Post using user credentials: calling ${this.name}: ${path}`)
+  private async requestWithBody<Response = unknown>(
+    method: 'patch' | 'post' | 'put',
+    { path, query = {}, headers = {}, responseType = '', data = {}, raw = false, retry = false }: RequestWithBody,
+  ): Promise<Response> {
+    logger.info(`${this.name} ${method.toUpperCase()}: ${path}`)
     try {
-      const result = await superagent
-        .post(`${this.apiUrl()}${path}`)
+      const result = await superagent[method](`${this.apiUrl()}${path}`)
+        .query(query)
         .send(data)
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
@@ -105,13 +104,56 @@ export default class RestClient {
       return raw ? result : result.body
     } catch (error) {
       const sanitisedError = sanitiseError(error)
-      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'POST'`)
+      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: '${method.toUpperCase()}'`)
       throw sanitisedError
     }
   }
 
-  async stream({ path = null, headers = {} }: StreamRequest = {}): Promise<unknown> {
-    logger.info(`Get using user credentials: calling ${this.name}: ${path}`)
+  async patch<Response = unknown>(request: RequestWithBody): Promise<Response> {
+    return this.requestWithBody('patch', request)
+  }
+
+  async post<Response = unknown>(request: RequestWithBody): Promise<Response> {
+    return this.requestWithBody('post', request)
+  }
+
+  async put<Response = unknown>(request: RequestWithBody): Promise<Response> {
+    return this.requestWithBody('put', request)
+  }
+
+  async delete<Response = unknown>({
+    path,
+    query = {},
+    headers = {},
+    responseType = '',
+    raw = false,
+  }: Request): Promise<Response> {
+    logger.info(`${this.name} DELETE: ${path}`)
+    try {
+      const result = await superagent
+        .delete(`${this.apiUrl()}${path}`)
+        .query(query)
+        .agent(this.agent)
+        .use(restClientMetricsMiddleware)
+        .retry(2, (err, res) => {
+          if (err) logger.info(`Retry handler found ${this.name} API error with ${err.code} ${err.message}`)
+          return undefined // retry handler only for logging retries, not to influence retry logic
+        })
+        .auth(this.token, { type: 'bearer' })
+        .set(headers)
+        .responseType(responseType)
+        .timeout(this.timeoutConfig())
+
+      return raw ? result : result.body
+    } catch (error) {
+      const sanitisedError = sanitiseError(error)
+      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'DELETE'`)
+      throw sanitisedError
+    }
+  }
+
+  async stream({ path = null, headers = {} }: StreamRequest = {}): Promise<Readable> {
+    logger.info(`${this.name} streaming: ${path}`)
     return new Promise((resolve, reject) => {
       superagent
         .get(`${this.apiUrl()}${path}`)
@@ -119,7 +161,7 @@ export default class RestClient {
         .auth(this.token, { type: 'bearer' })
         .use(restClientMetricsMiddleware)
         .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          if (err) logger.info(`Retry handler found ${this.name} API error with ${err.code} ${err.message}`)
           return undefined // retry handler only for logging retries, not to influence retry logic
         })
         .timeout(this.timeoutConfig())

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -19,7 +19,7 @@ describe('GET 404', () => {
       .expect(404)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('NotFoundError: Not found')
+        expect(res.text).toContain('NotFoundError: Not Found')
         expect(res.text).not.toContain('Something went wrong. The error has been logged. Please try again')
       })
   })
@@ -31,7 +31,7 @@ describe('GET 404', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Something went wrong. The error has been logged. Please try again')
-        expect(res.text).not.toContain('NotFoundError: Not found')
+        expect(res.text).not.toContain('NotFoundError: Not Found')
       })
   })
 })

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -1,6 +1,6 @@
 import express, { Express } from 'express'
 import cookieSession from 'cookie-session'
-import createError from 'http-errors'
+import { NotFound } from 'http-errors'
 
 import routes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
@@ -17,13 +17,13 @@ const testAppInfo: ApplicationInfo = {
   branchName: 'main',
 }
 
-export const user = {
-  firstName: 'first',
-  lastName: 'last',
+export const user: Express.User = {
+  name: 'FIRST LAST',
   userId: 'id',
   token: 'token',
   username: 'user1',
   displayName: 'First Last',
+  active: true,
   activeCaseLoadId: 'MDI',
   authSource: 'NOMIS',
 }
@@ -40,14 +40,15 @@ function appSetup(services: Services, production: boolean, userSupplier: () => E
   app.use((req, res, next) => {
     req.user = userSupplier()
     req.flash = flashProvider
-    res.locals = {}
-    res.locals.user = { ...req.user }
+    res.locals = {
+      user: { ...req.user },
+    }
     next()
   })
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
   app.use(routes(services))
-  app.use((req, res, next) => next(createError(404, 'Not found')))
+  app.use((req, res, next) => next(new NotFound()))
   app.use(errorHandler(production))
 
   return app

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,5 +1,5 @@
 import UserService from './userService'
-import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
+import HmppsAuthClient, { type User } from '../data/hmppsAuthClient'
 
 jest.mock('../data/hmppsAuthClient')
 
@@ -14,6 +14,7 @@ describe('User service', () => {
       hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
       userService = new UserService(hmppsAuthClient)
     })
+
     it('Retrieves and formats user name', async () => {
       hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
 
@@ -21,6 +22,7 @@ describe('User service', () => {
 
       expect(result.displayName).toEqual('John Smith')
     })
+
     it('Propagates error', async () => {
       hmppsAuthClient.getUser.mockRejectedValue(new Error('some error'))
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,8 +1,8 @@
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
+import type { User } from '../data/hmppsAuthClient'
 
-interface UserDetails {
-  name: string
+export interface UserDetails extends User {
   displayName: string
 }
 


### PR DESCRIPTION
REST client improvements:
- Adds commonly used PATCH, PUT and DELETE methods
- Allows passing query parameters to all methods (so you don't need to build a complex url path remembering to `encodeURIComponent`)
- Makes response body type generic (was always `unknown`)

Also, propagate user types into `res.locals` in request handlers.

Before:

```
 PASS  server/data/restClient.test.ts
  POST
    ✓ Should return response body
    ✓ Should return raw response body
    ✓ Should not retry by default
    ✓ retries if configured to do so
    ✓ can recover through retries
```

After:

```
 PASS  server/data/restClient.test.ts
  Method: get
    ✓ should return response body
    ✓ should return raw response body
    ✓ should retry by default
    ✓ can recover through retries
  Method: patch
    ✓ should return response body
    ✓ should return raw response body
    ✓ should not retry by default
    ✓ should retry if configured to do so
    ✓ can recover through retries
  Method: post
    ✓ should return response body
    ✓ should return raw response body
    ✓ should not retry by default
    ✓ should retry if configured to do so
    ✓ can recover through retries
  Method: put
    ✓ should return response body
    ✓ should return raw response body
    ✓ should not retry by default
    ✓ should retry if configured to do so
    ✓ can recover through retries
  Method: delete
    ✓ should return response body
    ✓ should return raw response body
    ✓ should retry by default
    ✓ can recover through retries
```