### PR TITLE
HAAR-1891: Add newly-included Manage Users api to health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+**November 6th 2023** – Add HMPPS Manage Users API to health checks
+
+PR: [#255](https://github.com/ministryofjustice/hmpps-template-typescript/pull/255)
+
+---
+
 **October 27th 2023** – Update to 4.0.0 of `jwt-decode` module
 
 This had breaking changes and required an update to the import statement

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -3,6 +3,7 @@ context('Healthcheck', () => {
     beforeEach(() => {
       cy.task('reset')
       cy.task('stubAuthPing')
+      cy.task('stubManageUsersPing')
       cy.task('stubTokenVerificationPing')
     })
 

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -37,7 +37,19 @@ const stubUserRoles = () =>
     },
   })
 
+const ping = () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/health/ping',
+    },
+    response: {
+      status: 200,
+    },
+  })
+
 export default {
   stubManageUser: (name = 'john smith'): Promise<[Response, Response]> =>
     Promise.all([stubUser(name), stubUserRoles()]),
+  stubManageUsersPing: ping,
 }

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -51,6 +51,7 @@ function gatherCheckInfo(aggregateStatus: Record<string, unknown>, currentStatus
 
 const apiChecks = [
   service('hmppsAuth', `${config.apis.hmppsAuth.url}/health/ping`, config.apis.hmppsAuth.agent),
+  service('manageUsersApi', `${config.apis.manageUsersApi.url}/health/ping`, config.apis.manageUsersApi.agent),
   ...(config.apis.tokenVerification.enabled
     ? [
         service(


### PR DESCRIPTION
I think this was missed off from #247 when moving a couple of calls from HMPPS Auth to HMPPS Manage Users