### PR TITLE
Remove getUserRoles as an api call and add as decoded from the token

### DIFF
--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -34,16 +34,4 @@ describe('manageUsersApiClient', () => {
       expect(output).toEqual(response)
     })
   })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeManageUsersApiClient
-        .get('/users/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await manageUsersApiClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
 })

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -28,10 +28,4 @@ export default class ManageUsersApiClient {
     logger.info('Getting user details: calling HMPPS Manage Users Api')
     return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
   }
-
-  getUserRoles(token: string): Promise<string[]> {
-    return ManageUsersApiClient.restClient(token)
-      .get<UserRole[]>({ path: '/users/me/roles' })
-      .then(roles => roles.map(role => role.roleCode))
-  }
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,9 +1,8 @@
 import UserService from './userService'
 import ManageUsersApiClient, { type User } from '../data/manageUsersApiClient'
+import createUserToken from '../testutils/createUserToken'
 
 jest.mock('../data/manageUsersApiClient')
-
-const token = 'some token'
 
 describe('User service', () => {
   let manageUsersApiClient: jest.Mocked<ManageUsersApiClient>
@@ -16,6 +15,7 @@ describe('User service', () => {
     })
 
     it('Retrieves and formats user name', async () => {
+      const token = createUserToken([])
       manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
 
       const result = await userService.getUser(token)
@@ -23,7 +23,17 @@ describe('User service', () => {
       expect(result.displayName).toEqual('John Smith')
     })
 
+    it('Retrieves and formats roles', async () => {
+      const token = createUserToken(['ROLE_ONE', 'ROLE_TWO'])
+      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+
+      const result = await userService.getUser(token)
+
+      expect(result.roles).toEqual(['ONE', 'TWO'])
+    })
+
     it('Propagates error', async () => {
+      const token = createUserToken([])
       manageUsersApiClient.getUser.mockRejectedValue(new Error('some error'))
 
       await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,9 +1,11 @@
+import { jwtDecode } from 'jwt-decode'
 import { convertToTitleCase } from '../utils/utils'
 import type { User } from '../data/manageUsersApiClient'
 import ManageUsersApiClient from '../data/manageUsersApiClient'
 
 export interface UserDetails extends User {
   displayName: string
+  roles: string[]
 }
 
 export default class UserService {
@@ -11,6 +13,11 @@ export default class UserService {
 
   async getUser(token: string): Promise<UserDetails> {
     const user = await this.manageUsersApiClient.getUser(token)
-    return { ...user, displayName: convertToTitleCase(user.name) }
+    return { ...user, roles: this.getUserRoles(token), displayName: convertToTitleCase(user.name) }
+  }
+
+  getUserRoles(token: string): string[] {
+    const { authorities: roles = [] } = jwtDecode(token) as { authorities?: string[] }
+    return roles.map(role => role.substring(role.indexOf('_') + 1))
   }
 }

--- a/server/testutils/createUserToken.ts
+++ b/server/testutils/createUserToken.ts
@@ -1,0 +1,14 @@
+import jwt from 'jsonwebtoken'
+
+export default function createUserToken(authorities: string[]) {
+  const payload = {
+    user_name: 'user1',
+    scope: ['read', 'write'],
+    auth_source: 'nomis',
+    authorities,
+    jti: 'a610a10-cca6-41db-985f-e87efb303aaf',
+    client_id: 'clientid',
+  }
+
+  return jwt.sign(payload, 'secret', { expiresIn: '1h' })
+}


### PR DESCRIPTION
### What

- Remove getUserRoles as an api call and get roles by decoding the token
- Add roles to the getUser(token) service method
- Update tests

### Why
This significantly reduces the number of calls needed to external services. In this case the api method getUserRoles(token) merely sends the token off to the manage-users-api which decodes it and sends back the result.
