### PR TITLE
HAAR-2061: Remove deprecated filed

### DIFF
--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -12,7 +12,6 @@ const stubUser = (name: string = 'john smith') =>
         'Content-Type': 'application/json;charset=UTF-8',
       },
       jsonBody: {
-        staffId: 231232,
         username: 'USER1',
         active: true,
         name,

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -9,8 +9,7 @@ export interface User {
   authSource?: string
   uuid?: string
   userId?: string
-  staffId?: number // deprecated, use userId
-  activeCaseLoadId?: string // deprecated, use user roles api
+  activeCaseLoadId?: string // Will be removed from User. For now, use 'me/caseloads' endpoint in 'nomis-user-roles-api'
 }
 
 export interface UserRole {


### PR DESCRIPTION
1 ) Removed staffId (userId has same info),
2) activeCaseLoadId : can be derived from 'me/caseloads' endpoint in 'nomis-user-roles-api'