### PR TITLE
Update the breadcrumb partial with display current page title toggle

### DIFF
--- a/server/views/partials/breadcrumb.njk
+++ b/server/views/partials/breadcrumb.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{% macro breadcrumb(pageTitle, breadcrumbList) %}
+{% macro breadcrumb(pageTitle, breadcrumbList, displayCurrentPageTitle="true") %}
 
   {% set rows = [ {
     text: "Home",
@@ -17,11 +17,15 @@
     ), rows) %}
   {% endfor %}
 
-  {% set completedRows = (rows.push(
-    {
-      text: pageTitle
-    }
-  ), rows) %}
+  {% if displayCurrentPageTitle %}
+    {% set completedRows = (rows.push(
+      {
+        text: pageTitle
+      }
+    ), rows) %}
+  {% else %}
+    {% set completedRows = rows %}
+  {% endif %}
 
 {{ govukBreadcrumbs({
   collapseOnMobile: true,


### PR DESCRIPTION
Adds a toggle - defaulting to true. To include or leave off the current page title from the breadcrumb partial. 