### PR TITLE
Update MoJ frontend, dropping jQuery which is no longer required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "^2.0.0",
+        "@ministryofjustice/frontend": "^2.1.0",
         "agentkeepalive": "^4.5.0",
         "applicationinsights": "^2.9.2",
         "body-parser": "^1.20.2",
@@ -25,7 +25,6 @@
         "govuk-frontend": "^5.0.0",
         "helmet": "^7.1.0",
         "http-errors": "^2.0.0",
-        "jquery": "^3.7.1",
         "jwt-decode": "^4.0.0",
         "nocache": "^4.0.0",
         "nunjucks": "^3.2.4",
@@ -1546,9 +1545,9 @@
       "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-2.0.0.tgz",
-      "integrity": "sha512-JbYtMKjbR3fe8l5y/cgWXHFPJbLg2y0nlRuibM6Vdn9WYWayB8VJkoCoeAh04Jz20QBhzL4lag7KpcP7xQjbqw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-2.1.0.tgz",
+      "integrity": "sha512-LekTR097OsFku0+sREn7gR3G7UvH7jATw40PvZH4mKtnE8hyyw0gDrCSvFYsRS4kPLDsoFqZ5l0Y3CZE9f364g==",
       "dependencies": {
         "govuk-frontend": "^5.0.0",
         "moment": "^2.27.0"
@@ -5557,7 +5556,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -7306,7 +7304,8 @@
     "node_modules/jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     ]
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^2.0.0",
+    "@ministryofjustice/frontend": "^2.1.0",
     "agentkeepalive": "^4.5.0",
     "applicationinsights": "^2.9.2",
     "body-parser": "^1.20.2",
@@ -107,7 +107,6 @@
     "govuk-frontend": "^5.0.0",
     "helmet": "^7.1.0",
     "http-errors": "^2.0.0",
-    "jquery": "^3.7.1",
     "jwt-decode": "^4.0.0",
     "nocache": "^4.0.0",
     "nunjucks": "^3.2.4",

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
       "stabilityDays": 5
     },
     {
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["typescript", "govuk-frontend"],
       "rangeStrategy": "bump",
       "stabilityDays": 0

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -21,17 +21,12 @@ export default function setUpStaticResources(): Router {
     '/node_modules/govuk-frontend/dist',
     '/node_modules/@ministryofjustice/frontend/moj/assets',
     '/node_modules/@ministryofjustice/frontend',
-    '/node_modules/jquery/dist',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })
 
   Array.of('/node_modules/govuk_frontend_toolkit/images').forEach(dir => {
     router.use('/assets/images/icons', express.static(path.join(process.cwd(), dir), cacheControl))
-  })
-
-  Array.of('/node_modules/jquery/dist/jquery.min.js').forEach(dir => {
-    router.use('/assets/js/jquery.min.js', express.static(path.join(process.cwd(), dir), cacheControl))
   })
 
   // Don't cache dynamic resources

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -25,10 +25,6 @@ export default function setUpStaticResources(): Router {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })
 
-  Array.of('/node_modules/govuk_frontend_toolkit/images').forEach(dir => {
-    router.use('/assets/images/icons', express.static(path.join(process.cwd(), dir), cacheControl))
-  })
-
   // Don't cache dynamic resources
   router.use(noCache())
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -2,8 +2,6 @@
 
 {% block head %}
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
-
-  <script src="/assets/js/jquery.min.js"></script> 
 {% endblock %}
 
 {% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}


### PR DESCRIPTION
Might be worth noting that cypress still bundles jquery so it will remain available for integration tests