### PR TITLE
Update Nunjucks component paths

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -32,9 +32,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
     [
       path.join(__dirname, '../../server/views'),
       'node_modules/govuk-frontend/dist/',
-      'node_modules/govuk-frontend/dist/components/',
       'node_modules/@ministryofjustice/frontend/',
-      'node_modules/@ministryofjustice/frontend/moj/components/',
     ],
     {
       autoescape: true,


### PR DESCRIPTION
`node_modules/govuk-frontend/dist/components/` was missing `govuk/`
before `components/`, however we don't really need both the higher-level
and lower-level paths here. For greater consistency, just using the
higher-level path to enable a single clearly-namespaced route to each
GOV.UK and MOJ Nunjucks component makes more sense. The lower-level path
is often unused on projects that use this template

Imports should therefore look like this:

```njk
{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
```

... and not this:

```njk
{% from "checkboxes/macro.njk" import govukCheckboxes %}
```