### PR TITLE
Setting node version for security audit and outdated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,10 +194,12 @@ workflows:
     jobs:
       - hmpps/npm_outdated:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          node_tag: << pipeline.parameters.node-version >>
           context:
             - hmpps-common-vars
       - hmpps/npm_security_audit:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          node_tag: << pipeline.parameters.node-version >>
           context:
             - hmpps-common-vars
       - hmpps/trivy_latest_scan:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+**February 29th 2024** – Use same node version for outdated check and security scan. This currently defaults to node 16
+
+PR: [#321](https://github.com/ministryofjustice/hmpps-template-typescript/pull/321)
+
 **February 15th 2024** – Move over to use Debian 12 based image (bookworm)
 
 PR: [#316](https://github.com/ministryofjustice/hmpps-template-typescript/pull/316)


### PR DESCRIPTION
Currently defaults to node 16