### PR TITLE
CDPS-721: Parameterising paths for prometheus metrics

### DIFF
--- a/server/monitoring/metricsApp.test.ts
+++ b/server/monitoring/metricsApp.test.ts
@@ -1,0 +1,43 @@
+import { Request } from 'express'
+import { normalizePath } from './metricsApp'
+
+describe('metricsApp', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('normalizePath', () => {
+    it('normalises asset paths', () => {
+      const req = {
+        url: 'http://localhost:3000/assets/stylesheets/application.css',
+      } as unknown as Request
+
+      expect(normalizePath(req, {})).toBe('/assets/#assetPath')
+    })
+
+    it('normalises parameterised paths', () => {
+      const req = {
+        route: { path: 'prisoner/:prisonerNumber/alerts' },
+        url: 'http://localhost:3000/prisoner/A1234AA/alerts',
+      } as unknown as Request
+
+      expect(normalizePath(req, {})).toBe('/prisoner/#val/alerts')
+    })
+
+    it('normalises prisoner numbers where path not available', () => {
+      const req = {
+        url: 'http://localhost:3000/prisoner/A1234AA/alerts',
+      } as unknown as Request
+
+      expect(normalizePath(req, {})).toBe('/prisoner/#val/alerts')
+    })
+
+    it('handles urls that have no parameterization', () => {
+      const req = {
+        url: 'http://localhost:3000/ping',
+      } as unknown as Request
+
+      expect(normalizePath(req, {})).toBe('/ping')
+    })
+  })
+})


### PR DESCRIPTION
With the advice of @marcus-bcl, we discovered in `hmpps-prisoner-profile` that we had a significant memory leak due to the way the `promBundle` middleware was collecting stats about the application endpoints.

Before this change the only parameterisation being done was on `/assets`.  This meant `/prisoner/A1234AA` and `/prisoner/B1234AA` etc were being treated as separate endpoints and therefore creating the memory leak as more and more different prisoner profiles and subpages were loaded.

We found that this manifested itself in a high rate of 502s.  It wasn't killing the pod since we didn't observe too many pod restarts but presumably every now and again a thread was dying and being restarted?