### PR TITLE
Add dotenv to ESBuild server watch

### DIFF
--- a/esbuild/esbuild.config.js
+++ b/esbuild/esbuild.config.js
@@ -50,7 +50,7 @@ function main() {
     let serverProcess = null
     chokidar.watch(['dist']).on('all', () => {
       if (serverProcess) serverProcess.kill()
-      serverProcess = spawn('node', ['dist/server.js'], { stdio: 'inherit' })
+      serverProcess = spawn('node', ['-r', 'dotenv/config', 'dist/server.js'], { stdio: 'inherit' })
     })
   }
 


### PR DESCRIPTION
- Fixed issue where .env files are not preloaded when using the new ESBuild watch setup