### PR TITLE
Tidy up esbuild processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
             - node_modules
             - build
             - dist
-            - assets/stylesheets
 
   unit_test:
     executor:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,12 +57,6 @@
           }
         ]
       }
-    },
-    {
-      "files": ["esbuild/**/*"],
-      "rules": {
-        "no-console": "off"
-      }
     }
   ],
 

--- a/.gitignore
+++ b/.gitignore
@@ -116,8 +116,6 @@ dist
 .pnp.*
 
 
-
-assets/stylesheets/*.css
 .idea
 .vscode
 dist/

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ To start the main services excluding the example typescript template app:
 
 `docker compose up --scale=app=0`
 
-Install dependencies using `npm install`, ensuring you are using `node v18.x` and `npm v9.x`
+Install dependencies using `npm install`, ensuring you are using `node v20`
 
 Note: Using `nvm` (or [fnm](https://github.com/Schniz/fnm)), run `nvm install --latest-npm` within the repository folder to use the correct version of node, and the latest version of npm. This matches the `engines` config in `package.json` and the CircleCI build config.
 
-And then, to build the assets and start the app with nodemon:
+And then, to build the assets and start the app with esbuild:
 
 `npm run start:dev`
 
@@ -95,7 +95,7 @@ For local running, start a test db and wiremock instance by:
 
 Then run the server in test mode by:
 
-`npm run start-feature` (or `npm run start-feature:dev` to run with nodemon)
+`npm run start-feature` (or `npm run start-feature:dev` to run with auto-restart on changes)
 
 And then either, run tests in headless mode with:
 

--- a/esbuild/app.config.js
+++ b/esbuild/app.config.js
@@ -3,10 +3,12 @@ const { typecheckPlugin } = require('@jgoz/esbuild-plugin-typecheck')
 const esbuild = require('esbuild')
 const glob = require('glob')
 
-module.exports = buildConfig => {
-  console.log('\u{1b}[1m\u{2728}  Building app....\u{1b}[0m')
-
-  esbuild
+/**
+ * Build typescript application into CommonJS
+ * @type {BuildStep}
+ */
+const buildApp = buildConfig => {
+  return esbuild
     .build({
       entryPoints: glob.sync(buildConfig.app.entryPoints),
       outdir: buildConfig.app.outDir,
@@ -26,4 +28,14 @@ module.exports = buildConfig => {
       console.error(e)
       process.exit(1)
     })
+}
+
+/**
+ * @param {BuildConfig} buildConfig
+ * @returns {Promise}
+ */
+module.exports = buildConfig => {
+  console.log('\u{1b}[1m\u{2728}  Building app....\u{1b}[0m')
+
+  return buildApp(buildConfig)
 }

--- a/esbuild/app.config.js
+++ b/esbuild/app.config.js
@@ -8,26 +8,21 @@ const glob = require('glob')
  * @type {BuildStep}
  */
 const buildApp = buildConfig => {
-  return esbuild
-    .build({
-      entryPoints: glob.sync(buildConfig.app.entryPoints),
-      outdir: buildConfig.app.outDir,
-      bundle: false,
-      sourcemap: true,
-      platform: 'node',
-      format: 'cjs',
-      plugins: [
-        typecheckPlugin(),
-        copy({
-          resolveFrom: 'cwd',
-          assets: buildConfig.app.copy,
-        }),
-      ],
-    })
-    .catch(e => {
-      console.error(e)
-      process.exit(1)
-    })
+  return esbuild.build({
+    entryPoints: glob.sync(buildConfig.app.entryPoints),
+    outdir: buildConfig.app.outDir,
+    bundle: false,
+    sourcemap: true,
+    platform: 'node',
+    format: 'cjs',
+    plugins: [
+      typecheckPlugin(),
+      copy({
+        resolveFrom: 'cwd',
+        assets: buildConfig.app.copy,
+      }),
+    ],
+  })
 }
 
 /**

--- a/esbuild/app.config.js
+++ b/esbuild/app.config.js
@@ -22,5 +22,8 @@ module.exports = buildConfig => {
         }),
       ],
     })
-    .catch(() => process.exit(1))
+    .catch(e => {
+      console.error(e)
+      process.exit(1)
+    })
 }

--- a/esbuild/app.config.js
+++ b/esbuild/app.config.js
@@ -30,7 +30,7 @@ const buildApp = buildConfig => {
  * @returns {Promise}
  */
 module.exports = buildConfig => {
-  console.log('\u{1b}[1m\u{2728}  Building app....\u{1b}[0m')
+  process.stderr.write('\u{1b}[1m\u{2728} Building app...\u{1b}[0m\n')
 
   return buildApp(buildConfig)
 }

--- a/esbuild/assets.config.js
+++ b/esbuild/assets.config.js
@@ -1,12 +1,17 @@
+const path = require('node:path')
+
 const { copy } = require('esbuild-plugin-copy')
 const { sassPlugin } = require('esbuild-sass-plugin')
 const { clean } = require('esbuild-plugin-clean')
 const esbuild = require('esbuild')
-const path = require('path')
 const { glob } = require('glob')
 
-const buildAdditionalAssets = buildConfig =>
-  esbuild.build({
+/**
+ * Copy additional assets into distribution
+ * @type {BuildStep}
+ */
+const buildAdditionalAssets = buildConfig => {
+  return esbuild.build({
     outdir: buildConfig.assets.outDir,
     plugins: [
       copy({
@@ -15,7 +20,12 @@ const buildAdditionalAssets = buildConfig =>
       }),
     ],
   })
+}
 
+/**
+ * Build scss and javascript assets
+ * @type {BuildStep}
+ */
 const buildAssets = buildConfig => {
   return esbuild.build({
     entryPoints: buildConfig.assets.entryPoints,
@@ -39,10 +49,14 @@ const buildAssets = buildConfig => {
   })
 }
 
+/**
+ * @param {BuildConfig} buildConfig
+ * @returns {Promise}
+ */
 module.exports = buildConfig => {
   console.log('\u{1b}[1m\u{2728}  Building assets....\u{1b}[0m')
 
-  Promise.all([buildAssets(buildConfig), buildAdditionalAssets(buildConfig)]).catch(e => {
+  return Promise.all([buildAssets(buildConfig), buildAdditionalAssets(buildConfig)]).catch(e => {
     console.error(e)
     process.exit(1)
   })

--- a/esbuild/assets.config.js
+++ b/esbuild/assets.config.js
@@ -54,7 +54,7 @@ const buildAssets = buildConfig => {
  * @returns {Promise}
  */
 module.exports = buildConfig => {
-  console.log('\u{1b}[1m\u{2728}  Building assets....\u{1b}[0m')
+  process.stderr.write('\u{1b}[1m\u{2728} Building assets...\u{1b}[0m\n')
 
   return Promise.all([buildAssets(buildConfig), buildAdditionalAssets(buildConfig)])
 }

--- a/esbuild/assets.config.js
+++ b/esbuild/assets.config.js
@@ -56,8 +56,5 @@ const buildAssets = buildConfig => {
 module.exports = buildConfig => {
   console.log('\u{1b}[1m\u{2728}  Building assets....\u{1b}[0m')
 
-  return Promise.all([buildAssets(buildConfig), buildAdditionalAssets(buildConfig)]).catch(e => {
-    console.error(e)
-    process.exit(1)
-  })
+  return Promise.all([buildAssets(buildConfig), buildAdditionalAssets(buildConfig)])
 }

--- a/esbuild/assets.config.js
+++ b/esbuild/assets.config.js
@@ -43,7 +43,7 @@ module.exports = buildConfig => {
   console.log('\u{1b}[1m\u{2728}  Building assets....\u{1b}[0m')
 
   Promise.all([buildAssets(buildConfig), buildAdditionalAssets(buildConfig)]).catch(e => {
-    console.log(e)
+    console.error(e)
     process.exit(1)
   })
 }

--- a/esbuild/esbuild.config.js
+++ b/esbuild/esbuild.config.js
@@ -52,8 +52,10 @@ const main = () => {
 
   const args = process.argv
   if (args.includes('--build')) {
-    buildApp(buildConfig)
-    buildAssets(buildConfig)
+    Promise.all([buildApp(buildConfig), buildAssets(buildConfig)]).catch(e => {
+      console.error(e)
+      process.exit(1)
+    })
   }
 
   if (args.includes('--dev-server')) {
@@ -67,12 +69,12 @@ const main = () => {
   if (args.includes('--watch')) {
     console.log('\u{1b}[1m\u{1F52D} Watching for changes...\u{1b}[0m')
     // Assets
-    chokidar.watch(['assets/**/*'], chokidarOptions).on('all', () => buildAssets(buildConfig))
+    chokidar.watch(['assets/**/*'], chokidarOptions).on('all', () => buildAssets(buildConfig).catch(console.error))
 
     // App
     chokidar
       .watch(['server/**/*'], { ...chokidarOptions, ignored: ['**/*.test.ts'] })
-      .on('all', () => buildApp(buildConfig))
+      .on('all', () => buildApp(buildConfig).catch(console.error))
   }
 }
 

--- a/esbuild/esbuild.config.js
+++ b/esbuild/esbuild.config.js
@@ -1,13 +1,20 @@
-const path = require('path')
+const { spawn } = require('node:child_process')
+const path = require('node:path')
+
 const { glob } = require('glob')
 const chokidar = require('chokidar')
-const { spawn } = require('child_process')
 const buildAssets = require('./assets.config')
 const buildApp = require('./app.config')
 
 const cwd = process.cwd()
+
+/**
+ * Configuration for build steps
+ * @type {BuildConfig}
+ */
 const buildConfig = {
   isProduction: process.env.NODE_ENV === 'production',
+
   app: {
     outDir: path.join(cwd, 'dist'),
     entryPoints: glob
@@ -34,7 +41,10 @@ const buildConfig = {
   },
 }
 
-function main() {
+const main = () => {
+  /**
+   * @type {chokidar.WatchOptions}
+   */
   const chokidarOptions = {
     persistent: true,
     ignoreInitial: true,
@@ -65,4 +75,5 @@ function main() {
       .on('all', () => buildApp(buildConfig))
   }
 }
+
 main()

--- a/esbuild/esbuild.config.js
+++ b/esbuild/esbuild.config.js
@@ -53,7 +53,7 @@ const main = () => {
   const args = process.argv
   if (args.includes('--build')) {
     Promise.all([buildApp(buildConfig), buildAssets(buildConfig)]).catch(e => {
-      console.error(e)
+      process.stderr.write(`${e}\n`)
       process.exit(1)
     })
   }
@@ -67,14 +67,16 @@ const main = () => {
   }
 
   if (args.includes('--watch')) {
-    console.log('\u{1b}[1m\u{1F52D} Watching for changes...\u{1b}[0m')
+    process.stderr.write('\u{1b}[1m\u{1F52D} Watching for changes...\u{1b}[0m\n')
     // Assets
-    chokidar.watch(['assets/**/*'], chokidarOptions).on('all', () => buildAssets(buildConfig).catch(console.error))
+    chokidar
+      .watch(['assets/**/*'], chokidarOptions)
+      .on('all', () => buildAssets(buildConfig).catch(e => process.stderr.write(`${e}\n`)))
 
     // App
     chokidar
       .watch(['server/**/*'], { ...chokidarOptions, ignored: ['**/*.test.ts'] })
-      .on('all', () => buildApp(buildConfig).catch(console.error))
+      .on('all', () => buildApp(buildConfig).catch(e => process.stderr.write(`${e}\n`)))
   }
 }
 

--- a/esbuild/index.d.ts
+++ b/esbuild/index.d.ts
@@ -1,0 +1,20 @@
+import type { BuildResult } from 'esbuild'
+
+export interface BuildConfig {
+  isProduction: boolean
+
+  app: {
+    outDir: string
+    entryPoints: string[]
+    copy: { from: string; to: string }[]
+  }
+
+  assets: {
+    outDir: string
+    entryPoints: string[]
+    copy: { from: string; to: string }[]
+    clear: string[]
+  }
+}
+
+export type BuildStep = (BuildConfig) => Promise<BuildResult>

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,10 +83,8 @@
         "lint-staged": "^15.2.7",
         "mocha-junit-reporter": "^2.2.1",
         "nock": "^13.5.4",
-        "nodemon": "^3.1.4",
         "prettier": "^3.3.2",
         "prettier-plugin-jinja-template": "^1.4.1",
-        "sass": "^1.77.6",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.2",
         "typescript": "^5.5.3"
@@ -4047,12 +4045,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -8038,12 +8030,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true
-    },
     "node_modules/immutable": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
@@ -10890,97 +10876,6 @@
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
-    "node_modules/nodemon": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
-      "integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -11704,12 +11599,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
     "node_modules/pump": {
@@ -12744,18 +12633,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sinon": {
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
@@ -13363,18 +13240,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dev": true,
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -13704,12 +13569,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -66,17 +66,6 @@
       "ts"
     ]
   },
-  "nodemonConfig": {
-    "ignore": [
-      ".circleci/*",
-      "migrations/*",
-      "node_modules/*",
-      "test/*",
-      "integration_tests/*"
-    ],
-    "delay": 2500,
-    "ext": "js,json,html,njk"
-  },
   "lint-staged": {
     "*.{ts,js,css}": [
       "prettier --write",
@@ -161,10 +150,8 @@
     "lint-staged": "^15.2.7",
     "mocha-junit-reporter": "^2.2.1",
     "nock": "^13.5.4",
-    "nodemon": "^3.1.4",
     "prettier": "^3.3.2",
     "prettier-plugin-jinja-template": "^1.4.1",
-    "sass": "^1.77.6",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.2",
     "typescript": "^5.5.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open --e2e --browser chrome",
-    "clean": "rm -rf dist build node_modules stylesheets",
+    "clean": "rm -rf dist node_modules",
     "rebuild": "npm run clean && npm i && npm run build"
   },
   "engines": {

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -15,8 +15,6 @@ export default function setUpStaticResources(): Router {
 
   Array.of(
     '/dist/assets',
-    '/dist/assets/stylesheets',
-    '/dist/assets/js',
     '/node_modules/govuk-frontend/dist/govuk/assets',
     '/node_modules/govuk-frontend/dist',
     '/node_modules/@ministryofjustice/frontend/moj/assets',


### PR DESCRIPTION
The idea is to improve changes from [hmpps-template-typescript#375](https://github.com/ministryofjustice/hmpps-template-typescript/pull/375) by:
- removing vestigial references to paths that are no longer used for building assets
- removing now-unused direct dev dependencies
- removing superfluous routes to static asset (there shouldn’t be multiple routes/urls to the same files)
- adding JSDoc-based typing information to esbuild scripts – while this does not _enforce_ correct types, it helps IDEs warn of errors
- preventing esbuild steps exiting on error so that, in watch mode, the parent process lives on; based on [hmpps-sentence-plan-ui#35](https://github.com/ministryofjustice/hmpps-sentence-plan-ui/pull/35)
- using `process.stderr.write` in place of `console.*` to not require eslint exception

Hopefully nothing controversial :)

Notes for anyone cherry-picking in future:
- run `npm run rebuild` after merging and resolving conflicts to ensure the build works in your application
- check that no css/js assets are loaded using the plain `/assets/…` prefix instead of `/assets/css/…` and `/assets/js/…` respectively
- remove local `/assets/stylesheets` directory to prevent older built assets from being committed accidentally