### PR TITLE
Silence asset manifest file error during tests

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -20,7 +20,9 @@ export default function nunjucksSetup(app: express.Express): void {
     const assetMetadataPath = path.resolve(__dirname, '../../assets/manifest.json')
     assetManifest = JSON.parse(fs.readFileSync(assetMetadataPath, 'utf8'))
   } catch (e) {
-    logger.error('Could not read asset manifest file')
+    if (process.env.NODE_ENV !== 'test') {
+      logger.error('Could not read asset manifest file')
+    }
   }
 
   const njkEnv = nunjucks.configure(


### PR DESCRIPTION
When running unit tests, the app runs from outside the compiled `/dist/` folder so the manifest.json file cannot be found. This floods test output with error messages which don’t really matter.

Eg. [CircleCI build job for this project](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-template-typescript/2910/workflows/52194750-3015-48f6-87d2-c68097b11aae/jobs/11097#step-103-12521_81)

<img src="https://github.com/user-attachments/assets/815440c8-e9ea-4330-8045-2bfcb8675f45" alt="Sample `npm test` output from CircleCI" width="25%"/>

This is an inelegant hack to silence them. `jest` tests don’t actually try to load any assets; there is no server running.

Alternatively, the `assetManifest` variable be conditional depending on where the code executes from, but that feels a bit unreliable…