### PR TITLE
Supporting starting a fresh application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+REDIS_ENABLED=false
+TOKEN_VERIFICATION_ENABLED=false
+
+# Credentials for allowing user access
+AUTH_CODE_CLIENT_ID=hmpps-typescript-template
+AUTH_CODE_CLIENT_SECRET=clientsecret
+
+# Credentials for API calls
+CLIENT_CREDS_CLIENT_ID=hmpps-typescript-template-system
+CLIENT_CREDS_CLIENT_SECRET=clientsecret

--- a/README.md
+++ b/README.md
@@ -62,26 +62,42 @@ These need to be requested from the auth team by filling in this [template](http
 
 ### Auth Code flow
 
-These are used to allow authenticated users to access the application. After the user is redirected from auth back to the application, the typescript app will use the returned auth code to request a JWT token for that user containing the user's roles. The JWT token will be verified and then stored in the user's session. 
+These are used to allow authenticated users to access the application. After the user is redirected from auth back to the application, the typescript app will use the returned auth code to request a JWT token for that user containing the user's roles. The JWT token will be verified and then stored in the user's session.
 
 These credentials are configured using the following env variables:
- * AUTH_CODE_CLIENT_ID
- * AUTH_CODE_CLIENT_SECRET
- 
-### Client Credentials flow 
 
-These are used by the application to request tokens to make calls to APIs. 
+- AUTH_CODE_CLIENT_ID
+- AUTH_CODE_CLIENT_SECRET
 
-Most API calls that occur as part of the request/response cycle will be on behalf of a user. 
-To make a call on behalf of a user, a username should be passed when requesting a system token. The username will then become part of the JWT and can be used downstream for auditing purposes. 
+### Client Credentials flow
 
-These tokens are cached in REDIS until expiration.  
+These are used by the application to request tokens to make calls to APIs. These are system accounts that will have their own sets of roles. 
+
+Most API calls that occur as part of the request/response cycle will be on behalf of a user.
+To make a call on behalf of a user, a username should be passed when requesting a system token. The username will then become part of the JWT and can be used downstream for auditing purposes.
+
+These tokens are cached until expiration.
 
 These credentials are configured using the following env variables:
- * CLIENT_CREDS_CLIENT_ID
- * CLIENT_CREDS_CLIENT_SECRET
 
-## Running the app
+- CLIENT_CREDS_CLIENT_ID
+- CLIENT_CREDS_CLIENT_SECRET
+
+### Dependencies
+
+### HMPPS Auth
+To allow authenticated users to access your application you need to point it to a running instance of `hmpps-auth`.
+By default the application is configured to run against an instance running in docker that can be started via `docker-compose`.
+
+**NB:** It's common for developers to run against the instance of auth running in the development/T3 environment for local development.
+Most APIs don't have images with cached data that you can run with docker: setting up realistic stubbed data in sync across a variety of services is very difficult.
+
+### REDIS
+
+When deployed to an environment with multiple pods we run applications with an instance of REDIS/Elasticache to provide a distributed cache of sessions.
+The template app is, by default, configured not to use REDIS when running locally.  
+
+## Running the app via docker-compose
 
 The easiest way to run the app is to use docker compose to create the service and all dependencies.
 
@@ -89,18 +105,14 @@ The easiest way to run the app is to use docker compose to create the service an
 
 `docker compose up`
 
-### Dependencies
-
-The app requires:
-
-- hmpps-auth - for authentication
-- redis - session store and token caching
-
 ### Running the app for development
 
 To start the main services excluding the example typescript template app:
 
 `docker compose up --scale=app=0`
+
+Create an environment file by copying `.env.example` -> `.env` 
+Environment variables set in here will be available when running `start:dev`
 
 Install dependencies using `npm install`, ensuring you are using `node v20`
 
@@ -109,6 +121,15 @@ Note: Using `nvm` (or [fnm](https://github.com/Schniz/fnm)), run `nvm install --
 And then, to build the assets and start the app with esbuild:
 
 `npm run start:dev`
+
+### Logging in with a test user
+
+Once the application is running you should then be able to login with:
+
+username: AUTH_USER
+password: password123456
+
+To request specific users and roles then raise a PR to [update the seed data](https://github.com/ministryofjustice/hmpps-auth/blob/main/src/main/resources/db/dev/data/auth/V900_3__users.sql) for the in-memory DB used by Auth
 
 ### Run linter
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,17 +28,19 @@ services:
     environment:
       - PRODUCT_ID=UNASSIGNED
       - REDIS_ENABLED=false
+      - REDIS_HOST=localhost
       - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
       # These will need to match new creds in the seed auth service auth
-      - AUTH_CODE_CLIENT_ID=client-id
-      - AUTH_CODE_CLIENT_SECRET=client-secret
-      - CLIENT_CREDS_CLIENT_ID=system-client-id
-      - CLIENT_CREDS_CLIENT_SECRET=system-client-secret
+      - AUTH_CODE_CLIENT_ID=hmpps-typescript-template
+      - AUTH_CODE_CLIENT_SECRET=clientsecret
+      - CLIENT_CREDS_CLIENT_ID=hmpps-typescript-template-system
+      - CLIENT_CREDS_CLIENT_SECRET=clientsecret
       - SESSION_SECRET=somesecretvalue
       - TOKEN_VERIFICATION_API_URL=http://hmpps-auth:8080/auth
       - TOKEN_VERIFICATION_ENABLED=false
       - INGRESS_URL=http://localhost:3000
+      - NO_HTTPS=true
 
 networks:
   hmpps:

--- a/server/config.ts
+++ b/server/config.ts
@@ -54,7 +54,7 @@ export default {
   gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   branchName: get('GIT_BRANCH', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   production,
-  https: production,
+  https: process.env.NO_HTTPS === 'true' ? false : production,
   staticResourceCacheDuration: '1h',
   redis: {
     enabled: get('REDIS_ENABLED', 'false', requiredInProduction) === 'true',


### PR DESCRIPTION
I've added a set of client credentials into the hmpps-auth seed database that can be used by anyone running docker locally.

* Fixed an issue where we can't create sessions when running in docker compose due to https only flag.
* Adding example.env file to allow running locally using npm.
* Fix issue with missing redis hostname in docker-compare
* Improve docs