### PR TITLE
HEAT-417 - cancel existing running workflows for non-main pipelines

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,6 +21,12 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+# This will cancel all running build/test/release pipelines that are not on the main branch
+# If this pipeline is on the main branch, it will wait until existing runs complete
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # main node build workflow
   node_build:


### PR DESCRIPTION
Add a few lines to the overall pipeline to cancel existing workflows, or wait if it's main.

This is the same as the default in CircleCI:

_Auto-cancel redundant workflows

With the exception of your default branch, we will automatically cancel any outstanding workflows on a branch when a newer pipeline is triggered on that branch. Scheduled workflows and re-runs are not auto-canceled._