### PR TITLE
Fix issue with AppInsights and multiple paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change log
 
+**March 7th 2025** - Fix issue with AppInsights
+
+Requests for routes that define multiple patterns were failing to be processed by appinsights and were not being exported e.g:
+
+```ts
+get(['/', '/:monitorType/:monitorName'], async (req, res) => {..
+```
+
+This would coerce the array into a string and fail with an error from app insights complaining about not accepting `,`s
+
+This now reports these kind of paths as an operation with a name like:
+
+`GET "/" | "/:monitorType/:monitorName"`
+
+See PR [#521](https://github.com/ministryofjustice/hmpps-template-typescript/pull/521)
+
 **November 29th 2024** - Moving to the new monitoring library
 
 There's a new set of [shared libraries](https://github.com/ministryofjustice/hmpps-typescript-lib) which should allow us to share code more efficiently than current approaches.

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -28,7 +28,10 @@ export function buildAppInsightsClient(
     defaultClient.addTelemetryProcessor(({ tags, data }, contextObjects) => {
       const operationNameOverride = contextObjects.correlationContext?.customProperties?.getProperty('operationName')
       if (operationNameOverride) {
-        tags['ai.operation.name'] = data.baseData.name = operationNameOverride // eslint-disable-line no-param-reassign,no-multi-assign
+        /*  eslint-disable no-param-reassign */
+        tags['ai.operation.name'] = operationNameOverride
+        data.baseData.name = operationNameOverride
+        /*  eslint-enable no-param-reassign */
       }
       return true
     })
@@ -43,7 +46,9 @@ export function appInsightsMiddleware(): RequestHandler {
     res.prependOnceListener('finish', () => {
       const context = getCorrelationContext()
       if (context && req.route) {
-        context.customProperties.setProperty('operationName', `${req.method} ${req.route?.path}`)
+        const path = req.route?.path
+        const pathToReport = Array.isArray(path) ? `"${path.join('" | "')}"` : path
+        context.customProperties.setProperty('operationName', `${req.method} ${pathToReport}`)
       }
     })
     next()


### PR DESCRIPTION
Requests for routes that define multiple patterns were failing to be processed by appinsights and were not being exported e.g:

```ts
get(['/', '/:monitorType/:monitorName'], async (req, res) => {..
```

This would coerce the array into a string and fail with an error from app insights complaining about not accepting `,`s

This now reports these kind of paths as an operation with a name like:

`GET "/" | "/:monitorType/:monitorName"`