### PR TITLE
Only restart dev server once esbuild complete

### DIFF
--- a/esbuild/esbuild.config.js
+++ b/esbuild/esbuild.config.js
@@ -9,6 +9,20 @@ const buildApp = require('./app.config')
 const cwd = process.cwd()
 
 /**
+ * Simple debounce helper
+ * @param {Function} fn - The function to debounce
+ * @param {number} delay - The delay in ms
+ * @returns {Function}
+ */
+function debounce(fn, delay = 200) {
+  let timeout
+  return (...args) => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => fn(...args), delay)
+  }
+}
+
+/**
  * Configuration for build steps
  * @type {BuildConfig}
  */
@@ -58,32 +72,35 @@ const main = () => {
     })
   }
 
-  if (args.includes('--dev-server')) {
+  let serverEnv
+  if (args.includes('--dev-server')) serverEnv = '.env'
+  if (args.includes('--dev-test-server')) serverEnv = 'feature.env'
+
+  if (serverEnv) {
     let serverProcess = null
-    chokidar.watch(['dist']).on('all', () => {
-      if (serverProcess) serverProcess.kill()
-      serverProcess = spawn('node', ['--env-file=.env', 'dist/server.js'], { stdio: 'inherit' })
-    })
-  }
-  if (args.includes('--dev-test-server')) {
-    let serverProcess = null
-    chokidar.watch(['dist']).on('all', () => {
-      if (serverProcess) serverProcess.kill()
-      serverProcess = spawn('node', ['--env-file=feature.env', 'dist/server.js'], { stdio: 'inherit' })
-    })
+    chokidar.watch(['dist']).on(
+      'all',
+      debounce(() => {
+        if (serverProcess) serverProcess.kill()
+        process.stdout.write(`Restarting server...\n`)
+        serverProcess = spawn('node', [`--env-file=${serverEnv}`, 'dist/server.js'], { stdio: 'inherit' })
+      }),
+    )
   }
 
   if (args.includes('--watch')) {
     process.stderr.write('\u{1b}[1m\u{1F52D} Watching for changes...\u{1b}[0m\n')
     // Assets
-    chokidar
-      .watch(['assets/**/*'], chokidarOptions)
-      .on('all', () => buildAssets(buildConfig).catch(e => process.stderr.write(`${e}\n`)))
+    chokidar.watch(['assets/**/*'], chokidarOptions).on(
+      'all',
+      debounce(() => buildAssets(buildConfig).catch(e => process.stderr.write(`${e}\n`))),
+    )
 
     // App
-    chokidar
-      .watch(['server/**/*'], { ...chokidarOptions, ignored: ['**/*.test.ts'] })
-      .on('all', () => buildApp(buildConfig).catch(e => process.stderr.write(`${e}\n`)))
+    chokidar.watch(['server/**/*'], { ...chokidarOptions, ignored: ['**/*.test.ts'] }).on(
+      'all',
+      debounce(() => buildApp(buildConfig).catch(e => process.stderr.write(`${e}\n`))),
+    )
   }
 }
 


### PR DESCRIPTION
## Context

In the context of the esbuild routine, the current approach to watching for file changes means that, when running a development server, a new server process is created and killed for _every single file found in the `dist` directory_. I have [replicated this with useful logging on a branch of our own repository](https://github.com/ministryofjustice/hmpps-approved-premises-ui/tree/esbuild-proceses-spawn-count), for which we've recently back-ported the template's esbuild config: when running the `npm run start:dev` command, you will see hundreds of `Started new server process with pid ...` being logged to the console.

This isn't an issue in itself (as long as we're happy that starting/killing processes willy-nilly is fine 😄), but, should you decide to keep your server running, while also attempting to run the integration tests in UI mode (`npm run test:integration:ui` in the linked demo of the issue, something we do regularly on our repository), a `pgrep` error occurs, killing both the integration test and server processes:

```
node:events:496
      throw er; // Unhandled 'error' event
      ^

Error: spawn pgrep EAGAIN
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -35,
  code: 'EAGAIN',
  syscall: 'spawn pgrep',
  path: 'pgrep',
  spawnargs: [ '-P', 48347 ]
}
```

A little bit of digging seemed to point to this pgrep error being linked to too many node processes/high PIDs, or something along those lines.

## Solution

Introduce a debounce on all calls to restart the server or build the app or assets (as suggested by @Thomas-Geraghty 😉). The debounce delay is set to 100ms, which seems sufficient to not hinder speed but also to prevent the issue described above.

### Also 

A couple of `process.stderr` calls have been switched to `process.stdout`, as they were not used to display errors.
