### PR TITLE
Change deprecated tsconfig option

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
   "jest": {
     "transform": {
       "^.+\\.tsx?$": [
-        "ts-jest",
-        {
-          "isolatedModules": true
-        }
+        "ts-jest"
       ]
     },
     "collectCoverageFrom": [

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -29,4 +29,5 @@ export const dataAccess = () => ({
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { HmppsAuthClient, RestClientBuilder, HmppsAuditClient }
+export { HmppsAuthClient, HmppsAuditClient }
+export type { RestClientBuilder }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/node22/tsconfig.json",
   "compileOnSave": true,
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "./dist",
     "sourceMap": true,
     "noEmit": false,


### PR DESCRIPTION
Had this pop up:

```ts-jest[config] (WARN) "isolatedModules" is deprecated and will be removed in v30.0.0. Please remove "isolatedModules" from your "ts-jest" transform options and enable "isolatedModules: true" in /Users/paul.solecki/moj/hmpps-content-hub-feedback-reports/tsconfig.json instead.```

This updates as suggested.