### PR TITLE
add discrete permissions for CodeQL scans

### DIFF
--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "19 6 * * MON-FRI" # Every weekday
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-npm-dependency-check:
     name: Project security npm dependency check

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "19 6 * * MON-FRI" # Every weekday
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-kotlin-trivy-check:
     name: Project security trivy dependency check

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "19 6 * * MON-FRI" # Every weekday
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-veracode-pipeline-scan:
     name: Project security veracode pipeline scan

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "34 6 * * 1" # Every Monday
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-veracode-policy-check:
     name: Project security veracode policy scan


### PR DESCRIPTION
Using CodeQL to scan Github Workflows reports issues with missing permissions.
These explicit permissions enable the scans to run without alerting.