### PR TITLE
Improve unit tests for Express 5’s handling of `req.body`

### DIFF
--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -38,7 +38,6 @@ function appSetup(services: Services, production: boolean, userSupplier: () => H
     res.locals = {
       user: { ...req.user } as HmppsUser,
     }
-    req.body = req.body || {}
     next()
   })
   app.use((req, res, next) => {


### PR DESCRIPTION
…by not sneakily ensuring it is always a concrete object. This code has no equivalent in the real application so could lull people into a false sense of security because in reality `req.body` can still be undefined and passing tests would miss it.

Amendment to #560