### PR TITLE
CDPS-1632: Removing pointless session middleware

### DIFF
--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -29,16 +29,6 @@ export default function setUpWebSession(): Router {
     }),
   )
 
-  // Update a value in the session so that redis resets the session TTL.
-  // Only changes every minute so that it's not updated with every request.
-  // This also has the effect of sending the set-cookie header to the browser
-  // which keeps the session alive there, although this is also taken care of
-  // by using rolling: true in the configuration above.
-  router.use((req, res, next) => {
-    req.session.nowInMinutes = Math.floor(Date.now() / 60e3)
-    next()
-  })
-
   router.use((req, res, next) => {
     const headerName = 'X-Request-Id'
     const oldValue = req.get(headerName)


### PR DESCRIPTION
In the typescript channel we were discussing whether this middleware that periodically updated a session value `nowInMinutes` was used for anything (see https://mojdt.slack.com/archives/C01AHT2AMCJ/p1757510026624619).

We have tested that the client cookie and backend redis session are kept alive without this extra middleware and have now removed it (and deployed this change to production) in the Prisoner Profile without issue.