### PR TITLE
Add npmrc security improvements

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -11,3 +11,9 @@ engine-strict = true
 
 # Show any output of scripts in the console 
 foreground-scripts = true
+
+# Wait a minimum of 7 days before allowing a package to be released, this is to allow time for any issues to be discovered and fixed before the package is released
+min-release-age = 7
+
+# Don't allow git dependencies see here
+allow-git = none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change log
 
+**March 30th 2026** - `.npmrc` security improvements.
+
+Adding new support for:
+
+* [disabling git dependencies](https://docs.npmjs.com/cli/v11/commands/npm-install#allow-git) 
+  * These can allow malicious actors to alias common executables with nefarious versions
+* [Set a minimum release age of dependencies](https://docs.npmjs.com/cli/v11/commands/npm-install#min-release-age) 
+  * To reduce risk of incorporating maliciously published packages
+
+To override min-release-age for manual audit fixes, might need to do: `npm audit fix --min-release-age=null`
+
+See PR [#706](https://github.com/ministryofjustice/hmpps-template-typescript/pull/706)
+
 **February 26th 2026** - Run lint, tests and type checking on package-lock changes.
 
 There was an issue where precommit hooks weren't firing for package-lock changes.


### PR DESCRIPTION
Adding new support for:

* [disabling git dependencies](https://docs.npmjs.com/cli/v11/commands/npm-install#allow-git) 
  * These can allow malicious actors to alias common executables with nefarious versions
* [Set a minimum release age of dependencies](https://docs.npmjs.com/cli/v11/commands/npm-install#min-release-age) 
  * To reduce risk of incorporating maliciously published packages


To override min-release-age for manual audit fixes, might need to do: `npm audit fix --min-release-age=null`