### PR TITLE
Fancier Wiremock interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+**June 25th 2026** - Fancier wiremock interface
+
+Should make it easier to write stubs correctly, especially when you want to match query parameters
+(using `urlPattern` is sensitive to parameter order so is not very effective).
+
+Since most apis will want a /health/ping stub, it’s convenient to have something to reuse and
+for the health check integration tests to be simpler to update.
+
+See PR [#774](https://github.com/ministryofjustice/hmpps-template-typescript/pull/774)
+
 **May 12th 2026** - Add codeql scan for typescript
 
 Adding an action for codeql security scanning of the application source code

--- a/integration_tests/mockApis/exampleApi.ts
+++ b/integration_tests/mockApis/exampleApi.ts
@@ -1,19 +1,8 @@
 import type { SuperAgentRequest } from 'superagent'
-import { stubFor } from './wiremock'
+import { stubFor, stubPing } from './wiremock'
 
 export default {
-  stubPing: (httpStatus = 200): SuperAgentRequest =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: '/example-api/health/ping',
-      },
-      response: {
-        status: httpStatus,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: { status: httpStatus === 200 ? 'UP' : 'DOWN' },
-      },
-    }),
+  stubPing: (httpStatus = 200): SuperAgentRequest => stubPing('/example-api', httpStatus),
 
   stubExampleTime: (httpStatus = 200): SuperAgentRequest =>
     stubFor({

--- a/integration_tests/mockApis/exampleApi.ts
+++ b/integration_tests/mockApis/exampleApi.ts
@@ -8,7 +8,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/example-api/example/time',
+        urlPath: '/example-api/example/time',
       },
       response: {
         status: httpStatus,

--- a/integration_tests/mockApis/hmppsAuth.ts
+++ b/integration_tests/mockApis/hmppsAuth.ts
@@ -26,8 +26,7 @@ export default {
     getMatchingRequests({
       method: 'GET',
       urlPath: '/auth/oauth/authorize',
-    }).then(data => {
-      const { requests } = data.body
+    }).then(requests => {
       const stateValue = requests[requests.length - 1].queryParams.state.values[0]
       return `/sign-in/callback?code=codexxxx&state=${stateValue}`
     }),

--- a/integration_tests/mockApis/hmppsAuth.ts
+++ b/integration_tests/mockApis/hmppsAuth.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken'
-import { stubFor, getMatchingRequests } from './wiremock'
+import type { SuperAgentRequest } from 'superagent'
+import { getMatchingRequests, stubFor, stubPing } from './wiremock'
 
 export interface UserToken {
   name?: string
@@ -31,7 +32,7 @@ export default {
       return `/sign-in/callback?code=codexxxx&state=${stateValue}`
     }),
 
-  favicon: () =>
+  favicon: (): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -42,18 +43,9 @@ export default {
       },
     }),
 
-  stubPing: () =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: '/auth/health/ping',
-      },
-      response: {
-        status: 200,
-      },
-    }),
+  stubPing: (httpStatus = 200): SuperAgentRequest => stubPing('/auth', httpStatus),
 
-  stubSignInPage: () =>
+  stubSignInPage: (): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -69,7 +61,7 @@ export default {
       },
     }),
 
-  stubSignOutPage: () =>
+  stubSignOutPage: (): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -84,7 +76,7 @@ export default {
       },
     }),
 
-  stubManageDetailsPage: () =>
+  stubManageDetailsPage: (): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -99,7 +91,7 @@ export default {
       },
     }),
 
-  token: (userToken: UserToken) =>
+  token: (userToken: UserToken): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',

--- a/integration_tests/mockApis/hmppsAuth.ts
+++ b/integration_tests/mockApis/hmppsAuth.ts
@@ -36,7 +36,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/favicon.ico',
+        urlPath: '/favicon.ico',
       },
       response: {
         status: 200,
@@ -95,7 +95,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        urlPattern: '/auth/oauth/token',
+        urlPath: '/auth/oauth/token',
       },
       response: {
         status: 200,

--- a/integration_tests/mockApis/tokenVerification.ts
+++ b/integration_tests/mockApis/tokenVerification.ts
@@ -8,7 +8,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        urlPattern: '/verification/token/verify',
+        urlPath: '/verification/token/verify',
       },
       response: {
         status: 200,

--- a/integration_tests/mockApis/tokenVerification.ts
+++ b/integration_tests/mockApis/tokenVerification.ts
@@ -1,19 +1,8 @@
 import { SuperAgentRequest } from 'superagent'
-import { stubFor } from './wiremock'
+import { stubFor, stubPing } from './wiremock'
 
 export default {
-  stubPing: (httpStatus = 200): SuperAgentRequest =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: '/verification/health/ping',
-      },
-      response: {
-        status: httpStatus,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: { status: httpStatus === 200 ? 'UP' : 'DOWN' },
-      },
-    }),
+  stubPing: (httpStatus = 200): SuperAgentRequest => stubPing('/verification', httpStatus),
 
   stubVerifyToken: (active = true): SuperAgentRequest =>
     stubFor({

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -2,12 +2,51 @@ import superagent, { SuperAgentRequest, Response } from 'superagent'
 
 const url = 'http://localhost:9091/__admin'
 
-const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
-  superagent.post(`${url}/mappings`).send(mapping)
+/**
+ * Incomplete definition of options used for creating a new stub mapping
+ * https://wiremock.org/docs/standalone/admin-api-reference/#tag/Stub-Mappings/operation/createNewStubMapping
+ */
+interface Mapping {
+  request?: {
+    method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+    queryParameters?: Record<string, { equalTo: string } | { matches: string }>
+    bodyPatterns?: ({ contains: string } | { equalToJson: unknown })[]
+  } & ({ url?: string } | { urlPath: string } | { urlPathPattern: string } | { urlPattern: string })
+  response?: {
+    status?: number
+    headers?: Record<string, string>
+  } & ({ jsonBody?: unknown } | { body: string } | { base64Body: string })
+}
 
-const getMatchingRequests = (body: string | object) => superagent.post(`${url}/requests/find`).send(body)
+export const stubFor = (mapping: Mapping): SuperAgentRequest => superagent.post(`${url}/mappings`).send(mapping)
 
-const resetStubs = (): Promise<Array<Response>> =>
+/**
+ * Incomplete definition of options used for searching requests
+ * https://wiremock.org/docs/standalone/admin-api-reference/#tag/Requests/operation/findRequestsByCriteria
+ */
+type FindRequestCriteria = {
+  method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+} & ({ url?: string } | { urlPath: string } | { urlPathPattern: string } | { urlPattern: string })
+
+/**
+ * Incomplete definition of requests found
+ * https://wiremock.org/docs/standalone/admin-api-reference/#tag/Requests/operation/findRequestsByCriteria
+ */
+interface FoundRequest {
+  method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+  url: string
+  absoluteUrl: string
+  headers: Record<string, string>
+  queryParams: Record<string, { key: string; values: string[] }>
+  body: string
+  bodyAsBase64: string
+}
+
+export const getMatchingRequests = (body: FindRequestCriteria): Promise<FoundRequest[]> =>
+  superagent
+    .post(`${url}/requests/find`)
+    .send(body)
+    .then(data => data.body.requests)
+
+export const resetStubs = (): Promise<Response[]> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
-
-export { stubFor, getMatchingRequests, resetStubs }

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -20,6 +20,19 @@ interface Mapping {
 
 export const stubFor = (mapping: Mapping): SuperAgentRequest => superagent.post(`${url}/mappings`).send(mapping)
 
+export const stubPing = (urlPrefix: string, httpStatus = 200): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPath: `${urlPrefix}/health/ping`,
+    },
+    response: {
+      status: httpStatus,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: { status: httpStatus === 200 ? 'UP' : 'DOWN' },
+    },
+  })
+
 /**
  * Incomplete definition of options used for searching requests
  * https://wiremock.org/docs/standalone/admin-api-reference/#tag/Requests/operation/findRequestsByCriteria

--- a/integration_tests/specs/health.spec.ts
+++ b/integration_tests/specs/health.spec.ts
@@ -5,6 +5,9 @@ import tokenVerification from '../mockApis/tokenVerification'
 
 import { resetStubs } from '../testUtils'
 
+// NB: add new mock apis here:
+const mockApis = [hmppsAuth, tokenVerification, exampleApi]
+
 test.describe('Health', () => {
   test.afterEach(async () => {
     await resetStubs()
@@ -12,7 +15,7 @@ test.describe('Health', () => {
 
   test.describe('All healthy', () => {
     test.beforeEach(async () => {
-      await Promise.all([hmppsAuth.stubPing(), exampleApi.stubPing(), tokenVerification.stubPing()])
+      await Promise.all(mockApis.map(api => api.stubPing()))
     })
 
     test('Health check is accessible and status is UP', async ({ page }) => {
@@ -35,11 +38,9 @@ test.describe('Health', () => {
   })
 
   test.describe('Some unhealthy', () => {
-    test.beforeEach(async () => {
-      await Promise.all([hmppsAuth.stubPing(), exampleApi.stubPing(), tokenVerification.stubPing(500)])
-    })
+    test('Health check status is down for 1 api', async ({ page }) => {
+      await Promise.all(mockApis.map(api => (api === tokenVerification ? api.stubPing(500) : api.stubPing())))
 
-    test('Health check status is down', async ({ page }) => {
       const response = await page.request.get('/health')
       const payload = await response.json()
       expect(payload.status).toBe('DOWN')
@@ -47,6 +48,12 @@ test.describe('Health', () => {
       expect(payload.components.tokenVerification.status).toBe('DOWN')
       expect(payload.components.tokenVerification.details.status).toBe(500)
       expect(payload.components.tokenVerification.details.attempts).toBe(3)
+      expect(
+        Object.values<{ status: 'UP' | 'DOWN' }>(payload.components).reduce(
+          (downCount, api) => (api.status === 'DOWN' ? downCount + 1 : downCount),
+          0,
+        ),
+      ).toEqual(1)
     })
   })
 })

--- a/integration_tests/testUtils.ts
+++ b/integration_tests/testUtils.ts
@@ -11,7 +11,7 @@ export const attemptHmppsAuthLogin = async (page: Page) => {
   await page.goto('/')
   page.locator('h1', { hasText: 'Sign in' })
   const url = await hmppsAuth.getSignInUrl()
-  await page.goto(url)
+  return page.goto(url)
 }
 
 export const login = async (
@@ -25,5 +25,5 @@ export const login = async (
     hmppsAuth.token({ name, roles, authSource }),
     tokenVerification.stubVerifyToken(active),
   ])
-  await attemptHmppsAuthLogin(page)
+  return attemptHmppsAuthLogin(page)
 }


### PR DESCRIPTION
This will make it easier to write stubs correctly, especially when you want to match query parameters (using `urlPattern` is sensitive to parameter order so is not very effective).

Since most apis will want a /health/ping stub, it’s convenient to have something to reuse and for the health check integration tests to be simpler to update.