### PR TITLE
Remove shutdown logging in azureAppInsights

### DIFF
--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,5 +1,4 @@
 import { initialiseTelemetry, flushTelemetry, telemetry } from '@ministryofjustice/hmpps-azure-telemetry'
-import logger from '../../logger'
 
 initialiseTelemetry({
   serviceName: 'hmpps-template-typescript',
@@ -12,7 +11,6 @@ initialiseTelemetry({
   .startRecording()
 
 const shutdown = async (signal: string) => {
-  logger.info(`${signal} received, shutting down...`)
   await flushTelemetry()
   process.exit(0)
 }

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -10,7 +10,7 @@ initialiseTelemetry({
   .addModifier(telemetry.processors.enrichSpanNameWithHttpRoute())
   .startRecording()
 
-const shutdown = async (signal: string) => {
+const shutdown = async () => {
   await flushTelemetry()
   process.exit(0)
 }

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -15,5 +15,5 @@ const shutdown = async () => {
   process.exit(0)
 }
 
-process.on('SIGTERM', () => shutdown('SIGTERM'))
-process.on('SIGINT', () => shutdown('SIGINT'))
+process.on('SIGTERM', () => shutdown())
+process.on('SIGINT', () => shutdown())


### PR DESCRIPTION
Logger was inadvertently being loaded before the azure-telemetry model, causing instrumentation to be incorrectly configured. Removing this logging fixes AppTraces reporting in Azure

Credits to @tpmcgowan who spotted the issue and suggested the fix