### PR TITLE
Use `minimumReleaseAge` in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major NPM dependencies",
       "groupSlug": "all-npm-minor-patch",
-      "stabilityDays": 7
+      "minimumReleaseAge": "7 days"
     },
     {
       "matchDepTypes": ["engines"],
@@ -21,7 +21,7 @@
     {
       "matchPackageNames": ["typescript", "govuk-frontend"],
       "rangeStrategy": "bump",
-      "stabilityDays": 0
+      "minimumReleaseAge": null
     },
     {
       "matchManagers": ["npm"],
@@ -47,7 +47,7 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "stabilityDays": 0
+    "minimumReleaseAge": null
   },
   "platformCommit": "enabled"
 }


### PR DESCRIPTION
This replaces the now deprecated `stabilityDays` (see https://docs.renovatebot.com/configuration-options/#minimumreleaseage)

This change was recommended by a renovate-generated PR on the approved-premises-ui repo (see https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/2971/changes)