### PR TITLE
Break out allowlists into separate categories

### DIFF
--- a/helm_deploy/hmpps-template-typescript/values.yaml
+++ b/helm_deploy/hmpps-template-typescript/values.yaml
@@ -59,9 +59,5 @@ generic-service:
     # sqs-hmpps-audit-secret:
     #   AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
 
-  allowlist:
-    groups:
-      - internal
-
 generic-prometheus-alerts:
   targetApplication: hmpps-template-typescript

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,9 +16,21 @@ generic-service:
     AUDIT_ENABLED: "false"
 
   allowlist:
+    # Configure groups as appropriate to give the minimum ingress access required:
+    #   digital_staff_and_mojo: devices on the MoJ network
+    #   moj_cloud_platform: services on Cloud Platform
+    # Other IP allowlist groups are here: 
+    # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
+
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
+
+  # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 
+  #       If you are intending to do this, please ensure you uncomment the 'modsecurity_enabled=true' 
+  #       entry in the ingress above. This will enable WAF protection of the endpoint. You will need 
+  #       to configure modsecurity rules to suit your needs. Further information can be found here:
+  #       https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#modsecurity-web-application-firewall
 
 
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,5 +15,12 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
 
+  allowlist:
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+
+
+
 generic-prometheus-alerts:
   alertSeverity: NON_PROD_ALERTS_SEVERITY_LABEL

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,5 +15,14 @@ generic-service:
     ENVIRONMENT_NAME: PRE-PRODUCTION
     AUDIT_ENABLED: "false"
 
+  allowlist:
+    # remove groups as appropriate to give the minimum ingress access required:
+    #   digital_staff_and_mojo: devices on the MoJ network
+    #   moj_cloud_platform: services on Cloud Platform
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+
+
 generic-prometheus-alerts:
   alertSeverity: NON_PROD_ALERTS_SEVERITY_LABEL

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,12 +16,23 @@ generic-service:
     AUDIT_ENABLED: "false"
 
   allowlist:
-    # remove groups as appropriate to give the minimum ingress access required:
+    # Configure groups as appropriate to give the minimum ingress access required:
     #   digital_staff_and_mojo: devices on the MoJ network
     #   moj_cloud_platform: services on Cloud Platform
+    # Other IP allowlist groups are here: 
+    # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
+
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
+
+  # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 
+  #       If you are intending to do this, please ensure you uncomment the 'modsecurity_enabled=true' 
+  #       entry in the ingress above. This will enable WAF protection of the endpoint. You will need 
+  #       to configure modsecurity rules to suit your needs. Further information can be found here:
+  #       https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#modsecurity-web-application-firewall
+
+
 
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,5 +12,14 @@ generic-service:
     EXAMPLE_API_URL: 'https://template-kotlin.hmpps.service.justice.gov.uk'
     AUDIT_ENABLED: "false"
 
+  allowlist:
+    # remove groups as appropriate to give the minimum ingress access required:
+    #   digital_staff_and_mojo: devices on the MoJ network
+    #   moj_cloud_platform: services on Cloud Platform
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+
+
 generic-prometheus-alerts:
   alertSeverity: PROD_ALERTS_SEVERITY_LABEL

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,12 +13,23 @@ generic-service:
     AUDIT_ENABLED: "false"
 
   allowlist:
-    # remove groups as appropriate to give the minimum ingress access required:
+    # Configure groups as appropriate to give the minimum ingress access required:
     #   digital_staff_and_mojo: devices on the MoJ network
     #   moj_cloud_platform: services on Cloud Platform
+    # Other IP allowlist groups are here: 
+    # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
+
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
+
+  # NOTE: Removing ALL allowlist groups will make the application accessible from the internet. 
+  #       If you are intending to do this, please ensure you uncomment the 'modsecurity_enabled=true' 
+  #       entry in the ingress above. This will enable WAF protection of the endpoint. You will need 
+  #       to configure modsecurity rules to suit your needs. Further information can be found here:
+  #       https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#modsecurity-web-application-firewall
+
+
 
 
 generic-prometheus-alerts:


### PR DESCRIPTION
This is to complete some work that Kristian did ages ago to give better granularity between MOJO network and Cloud Platforms.
Obviously this has security benefits (if developers choose to take it up).

There's some words around the use of allowlists / modsec.